### PR TITLE
compressed_iso: support loading libchdr on Windows

### DIFF
--- a/pc/compressed_iso/chd.py
+++ b/pc/compressed_iso/chd.py
@@ -10,6 +10,7 @@ Build from source: https://github.com/rtissera/libchdr
 
 import ctypes
 import ctypes.util
+import os
 import struct
 
 from .base import CompressedFileWrapper
@@ -22,7 +23,10 @@ from .base import CompressedFileWrapper
 def _load_libchdr():
     """Attempt to load libchdr. Returns loaded ctypes.CDLL or raises ImportError."""
     name = ctypes.util.find_library("chdr")
-    candidates = ["libchdr.so.0", "libchdr.so"]
+    # Windows: prefer a libchdr.dll placed next to this module, then PATH
+    module_dir = os.path.dirname(os.path.abspath(__file__))
+    candidates = [os.path.join(module_dir, "libchdr.dll"), "libchdr.dll",
+                  "chdr.dll", "libchdr.so.0", "libchdr.so"]
     if name:
         candidates.insert(0, name)
     for candidate in candidates:


### PR DESCRIPTION
## Problem

`_load_libchdr()` only tries Linux shared-object names (`libchdr.so.0`, `libchdr.so`), so CHD support can never load on Windows even when a libchdr build is available.

## Fix

Also try Windows DLL names, preferring a `libchdr.dll` placed next to the module (simplest deployment: drop the DLL into `compressed_iso/`), then `libchdr.dll`/`chdr.dll` from `PATH`, then the existing `.so` fallbacks. `ctypes.util.find_library` results, when present, still take priority on all platforms.

## Notes

A working `libchdr.dll` cross-compiles cleanly from the official rtissera/libchdr source with mingw-w64 (`-DCMAKE_SYSTEM_NAME=Windows -DBUILD_SHARED_LIBS=ON`, static libgcc — the result only imports KERNEL32/msvcrt). Happy to contribute the build recipe to the docs if wanted.

## Testing

Running in production since August 2026 on Windows 10, streaming ~800 CHD titles to a PS2 through this loader with a mingw-built `libchdr.dll` next to `chd.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
