### PR TITLE
Add optional dual-port in-game reset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Options:
 
   -cfg=<file>       Load extra user/game specific config file (without .toml extension)
 
+  -igr-path=<file>  In-game-reset destination (empty returns to PS2 Browser)
+  -igr-power=<0|1>  Route a short power-button press through in-game reset
+
   -dbc              Enable debug colors
   -logo             Enable logo (adds rom0:PS2LOGO to arguments)
   -qb               Quick-Boot directly into load environment
@@ -175,6 +178,26 @@ Usage examples:
   neutrino.elf -bsd=ata -bsdfs=hdl -dvd=hdl:filename.iso
   neutrino.elf -bsd=udpbd -bsdfs=bd -dvd=bdfs:udp0p0
 ```
+
+## In-game reset
+
+The resident EE core supports **L1+L2+R1+R2+Start+Select** to leave a running
+game. `-igr-path=<file>` selects the destination ELF; when it is omitted,
+Neutrino follows Open PS2 Loader's convention and returns to the PS2 Browser.
+`-igr-power=1` additionally routes a short front-panel power-button press
+through the same reset path. It is disabled by default so normal power-off
+behavior is preserved for standalone installations.
+
+This implementation is adapted from Open PS2 Loader's EE-core in-game-reset
+and pad-open hooking code. The original copyright notices and Academic Free
+License 3.0 attribution are retained in `ee/ee_core/src/padhook.c` and
+`ee/ee_core/include/padhook.h`.
+
+The dual-controller and Q-Ball compatibility changes are still a
+hardware-testing feature, not a general release guarantee. Games that cannot
+safely tolerate the resident pad hook can select compatibility Mode 6 to
+disable IGR. See [`docs/igr-hardware-testing.md`](docs/igr-hardware-testing.md)
+for the current validation boundary.
 
 ## UDPFS / UDPBD PC Server
 

--- a/common/include/eecore_config.h
+++ b/common/include/eecore_config.h
@@ -29,6 +29,11 @@ typedef struct
 #define EECORE_FLAG_GSM_NO_576P (1<<2) // GSM: BIOS < 2.10 = no 576p support
 #define EECORE_FLAG_LOGO_PATCH  (1<<3) // PS2LOGO: apply region patch (console region ≠ game region)
 #define EECORE_FLAG_LOGO_PAL    (1<<4) // PS2LOGO: force PAL mode (only meaningful if LOGO_PATCH set)
+#define EECORE_FLAG_DISABLE_IGR (1<<5) // Do not hook libpad or install in-game reset
+
+#define EECORE_IGR_EXIT_PATH_MAX 256
+#define EECORE_IGR_ABI_MAGIC 0x49475231u /* "IGR1" */
+#define EECORE_IGR_FLAG_POWER_BUTTON_RESET (1u << 0)
 
 enum EECORE_GSM_VMODE
 {
@@ -68,6 +73,17 @@ struct ee_core_data
     void *ModStorageEnd;
     // Checksums for modules at: 0x95000 - 0xb5000 = 128KiB
     uint32_t mod_checksum_4k[EEC_MOD_CHECKSUM_COUNT];
+
+    // Optional in-game-reset destination. Empty follows OPL and returns to the
+    // PS2 Browser. The physical power button is intercepted only when enabled;
+    // the controller combo remains available regardless of this flag.
+    uint32_t IGRFlags;
+    char IGRExitPath[EECORE_IGR_EXIT_PATH_MAX];
+
+    // Keep this marker at the very end. That preserves the reset-field offsets
+    // used by the first IGR-capable loader while allowing a newer loader to
+    // reject an older, smaller ee_core before copying past its settings.
+    uint32_t IGRABIMagic;
 } __attribute__((packed, aligned(4)));
 
 extern struct ee_core_data eec;

--- a/docs/igr-hardware-testing.md
+++ b/docs/igr-hardware-testing.md
@@ -1,0 +1,39 @@
+# In-game reset hardware-testing notes
+
+This branch preserves the current OPL-derived Neutrino reset implementation.
+It adds:
+
+- controller-combo detection on physical controller ports 0 and 1;
+- repeated libpad/libpad2 discovery for games that load their pad library
+  after the initial ELF starts;
+- an optional short front-panel power-button reset path;
+- a two-stage clean return to the configured launcher ELF;
+- explicit loader/EE-core ABI validation and visible launch errors; and
+- compatibility Mode 6 (`DISABLE_IGR`) for titles that cannot safely use the
+  resident controller hook.
+
+The controller combo is **L1+L2+R1+R2+Start+Select**. The destination is passed
+with `-igr-path`; `-igr-power=1` opts into front-panel short-press reset.
+
+This is not yet a universal compatibility claim. Reset has worked on real
+hardware in several titles, but other games have frozen, damaged the resident
+worker, or required Mode 6. Q-Ball and similar titles remain targeted
+compatibility work. Before a release, test game boot, normal controller input,
+reset from both controller ports, audio after return, a second game launch,
+and repeated reset cycles across a representative title set.
+
+`ee/ee_core/include/padpatterns.h` is tracked with the port so a clean clone
+does not depend on an unpublished local build input. It retains the upstream
+Open PS2 Loader AFL-3.0 attribution.
+
+## Preservation build results
+
+- Two independent EE-core builds were byte-identical: 34,528 bytes, SHA-256
+  `1B8F7A4AB702AFC3C5A3BB09B085107DD112C9A70EE6CF9D77F3F976DBA90194`.
+- The loader built successfully: 76,756 bytes, SHA-256
+  `518F09CF62B70294AD2788D3E616C33048936E954ACD7807AD694CED67B8C873`.
+- A full build with the newer local PS2SDK stopped in the existing cdvdfsv
+  IRX fixup step because that toolchain rejects a zero-valued exported text
+  symbol. Produce release bundles with the project's pinned
+  `ps2max/dev:v20260228` environment; that container was not installed on the
+  preservation workstation.

--- a/ee/ee_core/Makefile
+++ b/ee/ee_core/Makefile
@@ -17,7 +17,7 @@ GSMCORE_EE_OBJS = gsm_api.o ee_exception_l2.o
 CHEATCORE_EE_OBJS = cheat_engine.o cheat_api.o
 
 EE_OBJS = main.o iopmgr.o loadfile.o util.o patches.o patches_asm.o \
-	  asm.o crt0.o ps2logo.o $(GSMCORE_EE_OBJS) $(CHEATCORE_EE_OBJS)
+	  asm.o crt0.o ps2logo.o padhook.o tlb.o $(GSMCORE_EE_OBJS) $(CHEATCORE_EE_OBJS)
 MAPFILE = ee_core.map
 
 EE_INCS := -I. -Iinclude -I../../common/include -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(GSKIT)/include

--- a/ee/ee_core/include/asm.h
+++ b/ee/ee_core/include/asm.h
@@ -14,6 +14,8 @@
 #include <sifdma.h>
 
 u32 Hook_SifSetDma(SifDmaTransfer_t *sdd, s32 len);
+int Hook_CreateThread(void *thread_param);
+int Hook_ExecPS2(void *entry, void *gp, int argc, char **argv);
 void CleanExecPS2(void *epc, void *gp, int argc, char **argv);
 
 #endif /* ASM */

--- a/ee/ee_core/include/gsm_api.h
+++ b/ee/ee_core/include/gsm_api.h
@@ -3,6 +3,7 @@
 
 
 void EnableGSM(void);
+void DisableGSM(void);
 
 
 #endif

--- a/ee/ee_core/include/iopmgr.h
+++ b/ee/ee_core/include/iopmgr.h
@@ -5,10 +5,14 @@
 void services_start(void);
 void services_exit(void);
 
+// Game-safe raw IOP reset used by IGR. Unlike PS2SDK's SifIopReset, this does
+// not stop SIF0 while a title may still be transmitting to the EE.
+int Reset_Iop(const char *arg, int mode);
 void New_Reset_Iop(const char *arg, int arglen);
 void New_Reset_Iop2(const char *arg, int arglen, int eeload);
 
 void Install_Kernel_Hooks(void);
+void Remove_Kernel_Hooks(void);
 
 
 #endif

--- a/ee/ee_core/include/padhook.h
+++ b/ee/ee_core/include/padhook.h
@@ -1,0 +1,93 @@
+/*
+  padhook.h - In-Game Reset (IGR) for Neutrino
+
+  Ported from Open-PS2-Loader's ee_core padhook (GPL / AFL 3.0):
+    Copyright 2009-2010, Ifcaro, jimmikaelkael & Polo
+    Copyright 2006-2008 Polo
+  PadOpen hooking inspired by ps2rd (jimmikaelkael, misfire).
+
+  Reset-only Neutrino port: the combo L1+L2+R1+R2+SELECT+START or the
+  console's front-panel reset/power button returns to the NHDDL dashboard.
+*/
+
+#ifndef PADHOOK_H
+#define PADHOOK_H
+
+#include <tamtypes.h>
+
+#define PADOPEN_HOOK  0
+#define PADOPEN_CHECK 1
+
+// Shared with the resident syscall hooks. A zero padOpen_hooked value tells
+// the ExecPS2/CreateThread hooks to retry after dynamically loaded game code
+// appears. disable_padOpen_hook guards IOP-reset/module-loading windows.
+extern int padOpen_hooked;
+extern int disable_padOpen_hook;
+
+// The resident worker is intentionally visible to the kernel syscall guards.
+// Games may manage arbitrary thread IDs; only this one ID is protected while
+// the current game-side IGR instance is active.
+extern volatile int IGR_Thread_ID;
+
+// Scans [mem_start, mem_end) for the game's libpad/libpad2 pad-open function
+// and (mode PADOPEN_HOOK) redirects its callers to our hook. Returns patched.
+int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode);
+
+// Installs the IGR thread and the VBLANK-END interrupt handler (idempotent).
+void Install_IGR(void);
+
+// Resets the stored thread/handler IDs (call once before first install).
+void Reset_Padhook(void);
+
+// CDVD power/reset button registers (same hardware path used by OPL IGR).
+#define CDVD_R_NDIN ((volatile u8 *)0xBF402005)
+#define CDVD_R_POFF ((volatile u8 *)0xBF402008)
+#define CDVD_R_SCMD ((volatile u8 *)0xBF402016)
+#define CDVD_R_SDIN ((volatile u8 *)0xBF402017)
+
+typedef struct
+{
+    u32 option;
+    int port;
+    int slot;
+    int number;
+    u8 name[16];
+} pad2socketparam_t;
+
+typedef struct
+{
+    u16 libpad;
+    u16 libversion;
+    u8 *pad_buf;
+    int vb_count;
+    int pos_combo1;
+    int pos_combo2;
+    int pos_state;
+    int pos_frame;
+    u8 combo_type;
+    u8 prev_frame;
+    u8 live;
+} paddata_t;
+
+typedef struct
+{
+    u32 *pattern;
+    u32 *mask;
+    int size;
+    u16 type; // libpad or libpad2
+    u16 version;
+} pattern_t;
+
+#define IGR_LIBPAD_NONE 0
+#define IGR_LIBPAD      1
+#define IGR_LIBPAD2     2
+
+#define IGR_PAD_STABLE_V1 0x06
+#define IGR_PAD_STABLE_V2 0x01
+
+#define IGR_COMBO_R1_L1_R2_L2  0xF0
+#define IGR_COMBO_START_SELECT 0xF6
+
+#define NB_PADOPEN_PATTERN 7
+
+#endif

--- a/ee/ee_core/include/padpatterns.h
+++ b/ee/ee_core/include/padpatterns.h
@@ -1,0 +1,389 @@
+/*
+  Copyright 2009-2010, Ifcaro, jimmikaelkael & Polo
+  Copyright 2006-2008 Polo
+  Licenced under Academic Free License version 3.0
+  Review Open-Ps2-Loader README & LICENSE files for further details.
+
+  Some parts of the code are taken from HD Project by Polo
+*/
+
+#ifndef PADPATTERNS_H
+#define PADPATTERNS_H
+
+#include <tamtypes.h>
+
+/*******************************************************
+ * For libpad support
+ *
+ * libpad          2.1.1.0
+ * libpad          2.1.3.0
+ * libpad          2.2.0.0
+ * libpad          2.3.0.0
+ * libpad          2.4.1.0
+ * libpad          2.5.0.0
+ * libpad          2.6.0.0
+ * libpad          2.7.0.0
+ * libpad          2.7.1.0
+ * libpad          2.8.0.0
+ * libpad          3.0.0.0
+ * libpad          3.0.1.0
+ * libpad          3.0.2.0
+ * libpad          3.1.0.0
+ */
+static u32 padPortOpenpattern0[] = {
+    0x27bdff50, //    addiu         sp, sp, $ff50
+    0xffb40050, //    sd            s4, $0050(sp)
+    0xffb30040, //    sd            s3, $0040(sp)
+    0x00c0a02d, //    daddu         s4, a2, zero
+    0xffb20030, //    sd            s2, $0030(sp)
+    0x0080982d, //    daddu         s3, a0, zero
+    0xffbf00a0, //    sd            ra, $00a0(sp)
+    0x00a0902d, //    daddu         s2, a1, zero
+    0xffbe0090, //    sd            fp, $0090(sp)
+    0x3282003f, //    andi          v0, s4, $003f
+    0xffb70080, //    sd            s7, $0080(sp)
+    0xffb60070, //    sd            s6, $0070(sp)
+    0xffb50060, //    sd            s5, $0060(sp)
+    0xffb10020, //    sd            s1, $0020(sp)
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00010, //    sd            s0, $0010(sp)
+    0x3c020000, //    lui           v0, $XXXX
+    0x8c430000, //    lw            v1, $XXXX(v0)
+    0x10600000, //    beq           v1, zero, $XXXXXXXX
+    0x3c040000, //    lui           a0, $XXXX
+    0x0280282d, //    daddu         a1, s4, zero
+    0x0c000000  //    jal           scePrintf
+};
+static u32 padPortOpenpattern0_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffff0000,
+    0xffff0000,
+    0xffff0000,
+    0xffffffff,
+    0xfc000000};
+
+/*******************************************************
+ * For libpad support
+ *
+ * libpad          2.1.0.0
+ */
+static u32 padPortOpenpattern1[] = {
+    0x27bdff50, //    addiu         sp, sp, $ff50
+    0xffb20030, //    sd            s2, $0030(sp)
+    0xffb40050, //    sd            s4, $0050(sp)
+    0x00c0902d, //    daddu         s2, a2, zero
+    0xffb30040, //    sd            s3, $0040(sp)
+    0x00a0a02d, //    daddu         s4, a1, zero
+    0xffbf00a0, //    sd            ra, $00a0(sp)
+    0x0080982d, //    daddu         s3, a0, zero
+    0xffbe0090, //    sd            fp, $0090(sp)
+    0x3242003f, //    andi          v0, s2, $003f
+    0xffb70080, //    sd            s7, $0080(sp)
+    0xffb60070, //    sd            s6, $0070(sp)
+    0xffb50060, //    sd            s5, $0060(sp)
+    0xffb10020, //    sd            s1, $0020(sp)
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00010, //    sd            s0, $0010(sp)
+    0x3c040000, //    lui           a0, $XXXX
+    0x0240282d, //    daddu         a1, s2, zero
+    0x0c000000  //    jal           kprintf
+};
+static u32 padPortOpenpattern1_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xfc000000};
+
+/*******************************************************
+ * For libpad support
+ *
+ * libpad          1.6.3.0
+ * libpad          2.0.0.0
+ */
+static u32 padPortOpenpattern2[] = {
+    0x27bdff60, //    addiu         sp, sp, $ff60
+    0xffb20030, //    sd            s2, $0030(sp)
+    0xffb70080, //    sd            s7, $0080(sp)
+    0x00c0902d, //    daddu         s2, a2, zero
+    0xffb60070, //    sd            s6, $0070(sp)
+    0x0080b82d, //    daddu         s7, a0, zero
+    0xffbf0090, //    sd            ra, $0090(sp)
+    0x00a0b02d, //    daddu         s6, a1, zero
+    0xffb50060, //    sd            s5, $0060(sp)
+    0x3242003f, //    andi          v0, s2, $003f
+    0xffb40050, //    sd            s4, $0050(sp)
+    0xffb30040, //    sd            s3, $0040(sp)
+    0xffb10020, //    sd            s1, $0020(sp)
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00010, //    sd            s0, $0010(sp)
+    0x3c040000, //    lui           a0, $XXXX
+    0x0240282d, //    daddu         a1, s2, zero
+    0x0c000000  //    jal           printf
+};
+static u32 padPortOpenpattern2_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xfc000000};
+
+/*******************************************************
+ * For libpad support
+ *
+ * libpad          1.5.0.0
+ */
+static u32 padPortOpenpattern3[] = {
+    0x27bdff70, //    addiu         sp, sp, $ff70
+    0xffb20030, //    sd            s2, $0030(sp)
+    0xffb50060, //    sd            s5, $0060(sp)
+    0x00c0902d, //    daddu         s2, a2, zero
+    0xffb40050, //    sd            s4, $0050(sp)
+    0x0080a82d, //    daddu         s5, a0, zero
+    0xffbf0080, //    sd            ra, $0080(sp)
+    0x00a0a02d, //    daddu         s4, a1, zero
+    0xffb60070, //    sd            s6, $0070(sp)
+    0x3242000f, //    andi          v0, s2, $000f
+    0xffb30040, //    sd            s3, $0040(sp)
+    0xffb10020, //    sd            s1, $0020(sp)
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00010, //    sd            s0, $0010(sp)
+    0x3c040000, //    lui           a0, $XXXX
+    0x0c000000  //    jal           printf
+};
+static u32 padPortOpenpattern3_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xfc000000};
+
+/**************************************************************************
+ * For libpad2 support
+ *
+ * libpad2  2.7.1.0
+ * libpad2  3.0.0.0
+ * libpad2  3.0.2.0
+ * libpad2  3.1.0.0
+ */
+static u32 pad2CreateSocketpattern0[] = {
+    0x27bdff90, //    addiu         sp, sp, $ff90
+    0x0080302d, //    daddu         a2, a0, zero
+    0xffb10040, //    sd            s1, $0040(sp)
+    0x00a0882d, //    daddu         s1, a1, zero
+    0xffbf0060, //    sd            ra, $0060(sp)
+    0xffb20050, //    sd            s2, $0050(sp)
+    0x3222003f, //    andi          v0, s1, $003f
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00030, //    sd            s0, $0030(sp)
+    0x3c040000, //    lui           a0, $XXXX
+    0x0c000000, //    jal           scePrintf
+    0x24840000, //    addiu         a0, a0, $XXXX
+    0x10000000, //    beq           zero, zero, $XXXXXXXX
+    0x2402ffff, //    addiu         v0, zero, $ffff
+    0x50c00000, //    beql          a2, zero, $XXXXXXXX
+    0xafa00000, //    sw            zero, $0000(sp)
+    0x8cc20000, //    lw            v0, $0000(a2)
+    0x8cc30004, //    lw            v1, $0004(a2)
+    0x8cc40008, //    lw            a0, $0008(a2)
+    0x8cc5000c, //    lw            a1, $000c(a2)
+    0xafa20000, //    sw            v0, $0000(sp)
+    0xafa30008, //    sw            v1, $0008(sp)
+    0xafa4000c, //    sw            a0, $000c(sp)
+    0xafa50010  //    sw            a1, $0010(sp)
+};
+static u32 pad2CreateSocketpattern0_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xfc000000,
+    0xffff0000,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff};
+
+/**************************************************************************
+ * For libpad2 support
+ *
+ * libpad2    2.7.0.0
+ */
+static u32 pad2CreateSocketpattern1[] = {
+    0x27bdff70, //    addiu         sp, sp, $ff70
+    0x0080302d, //    daddu         a2, a0, zero
+    0xffb30060, //    sd            s3, $0060(sp)
+    0x00a0982d, //    daddu         s3, a1, zero
+    0xffbf0080, //    sd            ra, $0080(sp)
+    0xffb40070, //    sd            s4, $0070(sp)
+    0x3262003f, //    andi          v0, s3, $003f
+    0xffb20050, //    sd            s2, $0050(sp)
+    0xffb10040, //    sd            s1, $0040(sp)
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00030, //    sd            s0, $0030(sp)
+    0x3c040000, //    lui           a0, $XXXX
+    0x0c000000, //    jal           scePrintf
+    0x24840000, //    addiu         a0, a0, $XXXX
+    0x10000000, //    beq           zero, zero, $XXXXXXXX
+    0x2402ffff, //    addiu         v0, zero, $ffff
+    0x50c00000, //    beql          a2, zero, $XXXXXXXX
+    0xafa00000, //    sw            zero, $0000(sp)
+    0x8cc20000, //    lw            v0, $0000(a2)
+    0x8cc30004, //    lw            v1, $0004(a2)
+    0x8cc40008, //    lw            a0, $0008(a2)
+    0x8cc5000c, //    lw            a1, $000c(a2)
+    0xafa20000, //    sw            v0, $0000(sp)
+    0xafa30008, //    sw            v1, $0008(sp)
+    0xafa4000c  //    sw            a0, $000c(sp)
+};
+static u32 pad2CreateSocketpattern1_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xfc000000,
+    0xffff0000,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff};
+
+/**************************************************************************
+ * For libpad2 support
+ *
+ * libpad2    2.5.0.0
+ */
+static u32 pad2CreateSocketpattern2[] = {
+    0x27bdff70, //    addiu         sp, sp, $ff70
+    0x0080302d, //    daddu         a2, a0, zero
+    0xffb30060, //    sd            s3, $0060(sp)
+    0x00a0982d, //    daddu         s3, a1, zero
+    0xffbf0080, //    sd            ra, $0080(sp)
+    0xffb40070, //    sd            s4, $0070(sp)
+    0x3262003f, //    andi          v0, s3, $003f
+    0xffb20050, //    sd            s2, $0050(sp)
+    0xffb10040, //    sd            s1, $0040(sp)
+    0x10400000, //    beq           v0, zero, $XXXXXXXX
+    0xffb00030, //    sd            s0, $0030(sp)
+    0x10000000, //    beq           zero, zero, $XXXXXXXX
+    0x2402ffff, //    addiu         v0, zero, $ffff
+    0x50c00000, //    beql          a2, zero, $XXXXXXXX
+    0xafa00000, //    sw            zero, $0000(sp)
+    0x8cc20000, //    lw            v0, $0000(a2)
+    0x8cc30004, //    lw            v1, $0004(a2)
+    0x8cc40008, //    lw            a0, $0008(a2)
+    0x8cc5000c, //    lw            a1, $000c(a2)
+    0xafa20000, //    sw            v0, $0000(sp)
+    0xafa30008, //    sw            v1, $0008(sp)
+    0xafa4000c, //    sw            a0, $000c(sp)
+    0xafa50010  //    sw            a1, $0010(sp)
+};
+static u32 pad2CreateSocketpattern2_mask[] = {
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffff0000,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff};
+
+#endif /* PADPATTERNS */

--- a/ee/ee_core/include/tlb.h
+++ b/ee/ee_core/include/tlb.h
@@ -1,0 +1,6 @@
+#ifndef TLB_H
+#define TLB_H
+
+void InitializeTLB(void);
+
+#endif

--- a/ee/ee_core/linkfile
+++ b/ee/ee_core/linkfile
@@ -40,8 +40,15 @@ MEMORY {
 	modules96  : ORIGIN = 0x000A7000, LENGTH = 356K
 }
 
-REGION_ALIAS("MAIN_REGION", ee_core84);
-REGION_ALIAS("STACK_REGION", stack84);
+/*
+ * Keep the reset/IGR resident core above the low BIOS-RAM range that some
+ * games overwrite after startup. The default 0x84000 build could leave the
+ * VBLANK handler and IGR thread intact while corrupting Reset_Iop() earlier
+ * in the image, matching a repeatable blue-stage freeze when either reset
+ * input called that function. Neutrino already defines this alternate layout.
+ */
+REGION_ALIAS("MAIN_REGION", ee_core96);
+REGION_ALIAS("STACK_REGION", stack96);
 
 PHDRS {
   text PT_LOAD;

--- a/ee/ee_core/src/asm.S
+++ b/ee/ee_core/src/asm.S
@@ -12,6 +12,7 @@
 
 #define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
 #include "as_reg_compat.h"
+#define PADOPEN_HOOK 0
 
 .set push
 .set noreorder
@@ -32,8 +33,18 @@
 
 /* iopmgr.c */
 .extern New_SifSetDma
+.extern Old_ExecPS2
+.extern Old_CreateThread
+.extern padOpen_hooked
+.extern disable_padOpen_hook
+
+/* padhook.c */
+.extern Install_PadOpen_Hook
+.extern Reset_Padhook
 
 .globl  Hook_SifSetDma
+.globl  Hook_ExecPS2
+.globl  Hook_CreateThread
 .globl  CleanExecPS2
 
 /*
@@ -106,6 +117,101 @@ Hook_SifSetDma:
     nop
 
 .end    Hook_SifSetDma
+
+/*
+ * Retry the pad-open scan at every user ELF transition. The target program
+ * has already been loaded when _ExecPS2 is called, but has not started yet.
+ */
+.ent Hook_ExecPS2
+Hook_ExecPS2:
+    /* Do not scan resident/BIOS executables below normal user memory. */
+    lui     $v0, 0x0010
+    sltu    $v0, $a0, $v0
+    bne     $v0, $zero, 1f
+    daddu   $s0, $a0, $zero
+    daddu   $s1, $a1, $zero
+    daddu   $s2, $a2, $zero
+    daddu   $s3, $a3, $zero
+
+    /* Syscall hooks cannot use the game's stack for resident C code. */
+    la      $sp, _stack_end
+
+    jal     Reset_Padhook
+    nop
+
+    /* Compatibility Mode 6 keeps the game's libpad completely untouched. */
+    la      $v1, disable_padOpen_hook
+    lw      $v0, 0x0000($v1)
+    bne     $v0, $zero, 2f
+    nop
+
+    lui     $a0, 0x0010
+    lui     $a1, 0x01ff
+    jal     Install_PadOpen_Hook
+    addiu   $a2, $zero, PADOPEN_HOOK
+    la      $v1, padOpen_hooked
+    sw      $v0, 0x0000($v1)
+
+2:
+    daddu   $a0, $s0, $zero
+    daddu   $a1, $s1, $zero
+    daddu   $a2, $s2, $zero
+    jal     InitRegsExecPS2
+    daddu   $a3, $s3, $zero
+1:
+    lw      $v0, Old_ExecPS2
+    jr      $v0
+    nop
+.end Hook_ExecPS2
+
+/*
+ * Some titles load libpad after their main ELF starts. OPL retries the scan
+ * while early game threads are being created; once patched, this becomes a
+ * straight tail-call to the original syscall.
+ */
+.ent Hook_CreateThread
+Hook_CreateThread:
+    la      $v1, disable_padOpen_hook
+    lw      $v0, 0x0000($v1)
+    bne     $v0, $zero, 2f
+    nop
+    la      $v1, padOpen_hooked
+    lw      $v0, 0x0000($v1)
+    bne     $v0, $zero, 2f
+
+    /* Match OPL's early/high-priority thread filter. */
+    lw      $v0, 0x0014($a0)
+    beq     $v0, $zero, 1f
+    nop
+    slti    $v0, $v0, 5
+    beq     $v0, $zero, 2f
+    nop
+    lw      $v0, 0x0018($a0)
+    bne     $v0, $zero, 2f
+    nop
+1:
+    /* Use the resident stack while scanning game memory from syscall context. */
+    daddu   $a1, $sp, $zero
+    la      $sp, _stack_end
+    addiu   $sp, $sp, -0x20
+    sd      $ra, 0x0000($sp)
+    sd      $a1, 0x0008($sp)
+    sd      $a0, 0x0010($sp)
+
+    lui     $a0, 0x0010
+    lui     $a1, 0x01ff
+    jal     Install_PadOpen_Hook
+    addiu   $a2, $zero, PADOPEN_HOOK
+    la      $v1, padOpen_hooked
+    sw      $v0, 0x0000($v1)
+    ld      $a0, 0x0010($sp)
+    ld      $ra, 0x0000($sp)
+    ld      $sp, 0x0008($sp)
+2:
+    lw      $v0, Old_CreateThread
+    jr      $v0
+    nop
+.end Hook_CreateThread
 
 .ent CleanExecPS2
 CleanExecPS2:

--- a/ee/ee_core/src/iopmgr.c
+++ b/ee/ee_core/src/iopmgr.c
@@ -6,6 +6,7 @@
 #include <loadfile.h>
 #include <sifrpc.h>
 #include <iopheap.h>
+#include <kernel.h>
 #include <sbv_patches.h>
 #include <syscallnr.h>
 
@@ -15,6 +16,7 @@
 #include "asm.h"
 #include "util.h"
 #include "eecore_config.h"
+#include "padhook.h"
 
 extern int _iop_reboot_count; // defined in libkernel (iopcontrol.c)
 
@@ -22,11 +24,28 @@ static int set_reg_hook = 0;
 static int get_reg_hook = 0;
 static int imgdrv_offset = 0;
 static void (*Direct_SetSyscall)(s32 syscall_num, void *handler);
-static int (*Old_SifSetReg)(u32 register_num, int register_value);
-static int (*Old_SifGetReg)(u32 register_num);
+// Kept visible to padhook.c so IGR can submit its raw reset packet directly
+// from the already-running resident thread. Some titles leave the standalone
+// Reset_Iop() call target unusable even though the IGR thread itself survives.
+int (*Old_SifSetReg)(u32 register_num, int register_value);
+int (*Old_SifGetReg)(u32 register_num);
 
 // Used by Hook_SifSetDma in asm.S
 u32 (*Old_SifSetDma)(SifDmaTransfer_t *sdd, s32 len);
+int (*Old_ExecPS2)(void *entry, void *gp, int argc, char **argv);
+int (*Old_CreateThread)(ee_thread_t *thread_param);
+
+// Some titles terminate/delete or suspend every thread they did not create,
+// then reuse the released ID. Keep the one resident reset worker alive while
+// a game is running; all other thread-management calls remain untouched.
+static int (*Old_DeleteThread)(int thread_id);
+static int (*Old_TerminateThread)(int thread_id);
+static int (*Old_iTerminateThread)(int thread_id);
+static int (*Old_SuspendThread)(int thread_id);
+static int (*Old_iSuspendThread)(int thread_id);
+
+int padOpen_hooked = 0;
+int disable_padOpen_hook = 1;
 
 int _SifExecModuleBuffer(const void *ptr, u32 size, u32 arg_len, const char *args, int *mod_res, int dontwait);
 
@@ -106,16 +125,20 @@ static void print_iop_args(int arg_len, const char *args)
 #endif
 
 //---------------------------------------------------------------------------
-// Reset IOP. This function replaces SifIopReset from the PS2SDK
-static int Reset_Iop(const char *arg, int mode)
+// Reset IOP. This function replaces SifIopReset from the PS2SDK.
+// Do not call SifStopDma here: some games continue sending across SIF0 while
+// IGR runs. Current OPL deliberately leaves SIF DMA enabled because stopping
+// it in that state can leave SIF permanently non-functional after the reset.
+int Reset_Iop(const char *arg, int mode)
 {
     static SifCmdResetData_t reset_pkt __attribute__((aligned(64)));
     struct t_SifDmaTransfer dmat;
     int arglen;
 
-    _iop_reboot_count++; // increment reboot counter to allow RPC clients to detect unbinding!
+    if (eec.flags & EECORE_FLAG_DBC)
+        *GS_REG_BGCOLOR = COLOR_LBLUE;
 
-    SifStopDma();
+    _iop_reboot_count++; // increment reboot counter to allow RPC clients to detect unbinding!
 
     for (arglen = 0; arg[arglen] != '\0'; arglen++)
         reset_pkt.arg[arglen] = arg[arglen];
@@ -131,13 +154,22 @@ static int Reset_Iop(const char *arg, int mode)
     dmat.attr = SIF_DMA_ERT | SIF_DMA_INT_O;
     SifWriteBackDCache(&reset_pkt, sizeof(reset_pkt));
 
+    if (eec.flags & EECORE_FLAG_DBC)
+        *GS_REG_BGCOLOR = COLOR_WHITE;
+
     DIntr();
     ee_kmode_enter();
     Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_BOOTEND);
 
+    if (eec.flags & EECORE_FLAG_DBC)
+        *GS_REG_BGCOLOR = COLOR_OLIVE;
+
     if (!Old_SifSetDma(&dmat, 1)) {
+        if (eec.flags & EECORE_FLAG_DBC)
+            *GS_REG_BGCOLOR = COLOR_RED;
         ee_kmode_exit();
         EIntr();
+        delay(1);
         return 0;
     }
 
@@ -393,7 +425,17 @@ u32 New_SifSetDma(SifDmaTransfer_t *sdd, s32 len)
 {
     struct _iop_reset_pkt *reset_pkt = (struct _iop_reset_pkt *)sdd->src;
 
+    // Games often reboot the IOP only after loading more EE code. Retry here
+    // just as OPL does; Install_IGR also enables the physical-button fallback
+    // when no supported libpad pattern has appeared yet.
+    if (!disable_padOpen_hook && !padOpen_hooked) {
+        Install_IGR();
+        padOpen_hooked = Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_HOOK);
+    }
+
+    disable_padOpen_hook = 1;
     New_Reset_Iop2(reset_pkt->arg, reset_pkt->arglen, 0);
+    disable_padOpen_hook = 0;
 
     // Ignore EE still trying to complete the IOP reset
     set_reg_hook = 4;
@@ -452,6 +494,48 @@ static int Hook_SifGetReg(u32 register_num)
     return Old_SifGetReg(register_num);
 }
 
+// These handlers run in kernel mode. Keep them deliberately leaf-like: no
+// logging, allocation, RPC, or calls back through the public syscall stubs.
+static int Hook_DeleteThread(int thread_id)
+{
+    if ((IGR_Thread_ID > 0) && (thread_id == IGR_Thread_ID))
+        return 0;
+
+    return Old_DeleteThread(thread_id);
+}
+
+static int Hook_TerminateThread(int thread_id)
+{
+    if ((IGR_Thread_ID > 0) && (thread_id == IGR_Thread_ID))
+        return 0;
+
+    return Old_TerminateThread(thread_id);
+}
+
+static int Hook_iTerminateThread(int thread_id)
+{
+    if ((IGR_Thread_ID > 0) && (thread_id == IGR_Thread_ID))
+        return 0;
+
+    return Old_iTerminateThread(thread_id);
+}
+
+static int Hook_SuspendThread(int thread_id)
+{
+    if ((IGR_Thread_ID > 0) && (thread_id == IGR_Thread_ID))
+        return 0;
+
+    return Old_SuspendThread(thread_id);
+}
+
+static int Hook_iSuspendThread(int thread_id)
+{
+    if ((IGR_Thread_ID > 0) && (thread_id == IGR_Thread_ID))
+        return 0;
+
+    return Old_iSuspendThread(thread_id);
+}
+
 //---------------------------------------------------------------------------
 // Replace SifSetDma, SifSetReg and SifGetReg syscalls in kernel
 void Install_Kernel_Hooks(void)
@@ -466,4 +550,60 @@ void Install_Kernel_Hooks(void)
 
     Old_SifGetReg = GetSyscallHandler(__NR_SifGetReg);
     SetSyscall(__NR_SifGetReg, &Hook_SifGetReg);
+
+    // Keep retrying the IGR pad hook across user ELF transitions and delayed
+    // libpad loads, using the same syscall lifecycle as OPL.
+    Old_CreateThread = GetSyscallHandler(__NR_CreateThread);
+    SetSyscall(__NR_CreateThread, &Hook_CreateThread);
+
+    Old_ExecPS2 = GetSyscallHandler(__NR__ExecPS2);
+    SetSyscall(__NR__ExecPS2, &Hook_ExecPS2);
+
+    Old_DeleteThread = GetSyscallHandler(__NR_DeleteThread);
+    SetSyscall(__NR_DeleteThread, &Hook_DeleteThread);
+
+    Old_TerminateThread = GetSyscallHandler(__NR_TerminateThread);
+    SetSyscall(__NR_TerminateThread, &Hook_TerminateThread);
+
+    Old_iTerminateThread = GetSyscallHandler(-__NR_iTerminateThread);
+    SetSyscall(-__NR_iTerminateThread, &Hook_iTerminateThread);
+
+    Old_SuspendThread = GetSyscallHandler(__NR_SuspendThread);
+    SetSyscall(__NR_SuspendThread, &Hook_SuspendThread);
+
+    Old_iSuspendThread = GetSyscallHandler(-__NR__iSuspendThread);
+    SetSyscall(-__NR__iSuspendThread, &Hook_iSuspendThread);
+}
+
+// Restore the ROM SIF syscalls before leaving the emulation environment.
+// A normal game-side IOP reset must keep these hooks, but IGR is intentionally
+// returning to a clean application and must not have its reset intercepted.
+void Remove_Kernel_Hooks(void)
+{
+    if (Old_SifSetDma != NULL)
+        SetSyscall(__NR_SifSetDma, Old_SifSetDma);
+    if (Old_SifSetReg != NULL)
+        SetSyscall(__NR_SifSetReg, Old_SifSetReg);
+    if (Old_SifGetReg != NULL)
+        SetSyscall(__NR_SifGetReg, Old_SifGetReg);
+    if (Old_CreateThread != NULL)
+        SetSyscall(__NR_CreateThread, Old_CreateThread);
+    if (Old_ExecPS2 != NULL)
+        SetSyscall(__NR__ExecPS2, Old_ExecPS2);
+    if (Old_DeleteThread != NULL)
+        SetSyscall(__NR_DeleteThread, Old_DeleteThread);
+    if (Old_TerminateThread != NULL)
+        SetSyscall(__NR_TerminateThread, Old_TerminateThread);
+    if (Old_iTerminateThread != NULL)
+        SetSyscall(-__NR_iTerminateThread, Old_iTerminateThread);
+    if (Old_SuspendThread != NULL)
+        SetSyscall(__NR_SuspendThread, Old_SuspendThread);
+    if (Old_iSuspendThread != NULL)
+        SetSyscall(-__NR__iSuspendThread, Old_iSuspendThread);
+
+    set_reg_hook = 0;
+    get_reg_hook = 0;
+    disable_padOpen_hook = 1;
+    FlushCache(0);
+    FlushCache(2);
 }

--- a/ee/ee_core/src/main.c
+++ b/ee/ee_core/src/main.c
@@ -22,6 +22,7 @@
 #include "cheat_api.h"
 #include "gsm_api.h"
 #include "eecore_config.h"
+#include "padhook.h"
 
 extern void *_stack_end;
 
@@ -30,7 +31,10 @@ static int callcount = 0;
 
 // Global data
 u32 g_ee_core_flags = 0; // easy to use copy for asm.S
-struct ee_core_data eec = {MODULE_SETTINGS_MAGIC};
+struct ee_core_data eec = {
+    .magic = MODULE_SETTINGS_MAGIC,
+    .IGRABIMagic = EECORE_IGR_ABI_MAGIC,
+};
 
 // This function is defined as weak in ps2sdkc, so how
 // we are not using time zone, so we can safe some KB
@@ -92,6 +96,9 @@ int main(int argc, char **argv)
         DPRINTF("Install kernel hooks\n");
         Install_Kernel_Hooks();
 
+        // Initialize in-game reset (IGR) state before the game loads
+        Reset_Padhook();
+
         // Start selected elf file (should be something like "cdrom0:\ABCD_123.45;1")
         LoadExecPS2(argv[0], argc - 1, &argv[1]);
     } else {
@@ -126,6 +133,16 @@ int main(int argc, char **argv)
             FlushCache(INVALIDATE_ICACHE);
 
             services_exit();
+
+            // The target ELF is now in memory. Let the resident ExecPS2 and
+            // CreateThread hooks scan it (and any code it loads later) for
+            // libpad. Installing the IGR thread before ExecPS2 is too early:
+            // the kernel tears those game resources down during the exec.
+            // OPL compatibility Mode 6: leave libpad completely untouched for
+            // titles whose controller initialization is incompatible with IGR.
+            disable_padOpen_hook =
+                !!(eec.flags & EECORE_FLAG_DISABLE_IGR) ||
+                !_strcmp(eec.GameID, "SLUS_202.62");
             CleanExecPS2((void *)elf.epc, (void *)elf.gp, argc, argv);
         }
 

--- a/ee/ee_core/src/padhook.c
+++ b/ee/ee_core/src/padhook.c
@@ -1,0 +1,758 @@
+/*
+  padhook.c - In-Game Reset (IGR) for Neutrino
+
+  Ported from Open-PS2-Loader's ee_core padhook (GPL / AFL 3.0):
+    Copyright 2009-2010, Ifcaro, jimmikaelkael & Polo
+    Copyright 2006-2008 Polo
+  PadOpen hooking inspired by ps2rd (jimmikaelkael, misfire).
+
+  Reset-only Neutrino port. The combo L1+L2+R1+R2+SELECT+START returns to the
+  configured launcher. Front-panel interception is an independent option.
+*/
+
+#include <kernel.h>
+#include <loadfile.h>
+#include <iopheap.h>
+#include <sbv_patches.h>
+#include <sifrpc.h>
+#include <iopcontrol.h>
+#include <string.h>
+
+#include "asm.h"
+#include "cheat_api.h"
+#include "ee_debug.h"
+#include "eecore_config.h"
+#include "gsm_api.h"
+#include "iopmgr.h"
+#include "util.h"
+#include "padhook.h"
+#include "padpatterns.h"
+#include "tlb.h"
+
+// EE DMA / GS hardware registers used by the reset sequence.
+// Defined locally because Neutrino's ee_core ships its own ee_regs.h
+// (a register-save struct) that shadows ps2sdk's hardware-register header.
+#define IGR_R_D_CTRL    ((volatile u32 *)0x1000e000)
+#define IGR_R_D_STAT    ((volatile u32 *)0x1000e010)
+#define IGR_R_D_ENABLER ((volatile u32 *)0x1000f520)
+#define IGR_R_D_ENABLEW ((volatile u32 *)0x1000f590)
+#define IGR_R_D0_CHCR   ((volatile u32 *)0x10008000)
+#define IGR_R_D1_CHCR   ((volatile u32 *)0x10009000)
+#define IGR_R_D2_CHCR   ((volatile u32 *)0x1000a000)
+#define IGR_R_D3_CHCR   ((volatile u32 *)0x1000b000)
+#define IGR_R_D4_CHCR   ((volatile u32 *)0x1000b400)
+#define IGR_R_D8_CHCR   ((volatile u32 *)0x1000d000)
+#define IGR_R_D9_CHCR   ((volatile u32 *)0x1000d400)
+#define IGR_R_GS_CSR    ((volatile u64 *)0x12001000)
+
+// Retain the hardware checkpoints for explicit -dbc troubleshooting without
+// flashing diagnostic colors during ordinary production use.
+#define IGR_DIAG_COLOR(color) do { \
+    if (eec.flags & EECORE_FLAG_DBC) \
+        *GS_REG_BGCOLOR = (color); \
+} while (0)
+
+// Interrupt-context ResetEE. ps2sdk exposes only ResetEE() (a normal
+// syscall); from inside an interrupt handler the interrupt variant must be
+// used, which the EE kernel selects via the negated syscall number
+// (__NR_ResetEE == 1).
+static inline void iResetEE(u32 init_bitfield)
+{
+    __asm__ volatile(
+        "move  $a0, %0\n"
+        "li    $v1, -1\n"
+        "syscall\n"
+        "nop\n"
+        :
+        : "r"(init_bitfield)
+        : "a0", "v1", "memory");
+}
+
+// scePadPortOpen / scePad2CreateSocket originals (captured during scan)
+static int (*scePadPortOpen)(int port, int slot, void *addr);
+static int (*scePad2CreateSocket)(pad2socketparam_t *SocketParam, void *addr);
+
+#define IGR_PHYSICAL_PAD_COUNT 2
+
+// One record for each physical controller socket. Multitap slots are
+// intentionally out of scope: index 0 is port 0/slot 0 and index 1 is
+// port 1/slot 0.
+static paddata_t Pad_Data[IGR_PHYSICAL_PAD_COUNT];
+static u16 IGR_Libpad = IGR_LIBPAD_NONE;
+static u16 IGR_Libversion = 0;
+static volatile u8 IGR_Reset_Requested = 0;
+
+volatile int IGR_Thread_ID = -1;
+static int IGR_Intc_ID = -1;
+static int IGR_Scanner_Thread_ID = -1;
+
+#define IGR_STACK_SIZE (4 * 1024)
+static u8 IGR_Stack[IGR_STACK_SIZE] __attribute__((aligned(16)));
+#define IGR_SCANNER_STACK_SIZE (1 * 1024)
+static u8 IGR_Scanner_Stack[IGR_SCANNER_STACK_SIZE] __attribute__((aligned(16)));
+
+extern void *_gp;
+extern void *_stack_end;
+extern int _iop_reboot_count;
+extern u32 (*Old_SifSetDma)(SifDmaTransfer_t *sdd, s32 len);
+extern int (*Old_SifSetReg)(u32 register_num, int register_value);
+
+// Resident storage for the IGR reset command. Keeping this out of the thread
+// stack also keeps the raw reset sequence small after a game has replaced its
+// normal EE execution environment.
+static SifCmdResetData_t IGR_Reset_Packet __attribute__((aligned(64)));
+
+/*
+ * Load NHDDL from a fresh ExecPS2 context.
+ *
+ * This intentionally does not run in the awakened game-side IGR thread. The
+ * kernel ExecPS2 transition destroys the game's threads/semaphores, resets EE
+ * peripheral state and gives this resident entry point a clean stack and GP.
+ * OPL uses the same two-stage design (IGR_Exit -> ExecPS2(t_loadElf) ->
+ * LoadElf -> ExecPS2(exit ELF)). Trying to bind LOADFILE and load NHDDL
+ * directly from the old priority-0 IGR thread consistently reached the final
+ * light-blue checkpoint and then froze on real hardware.
+ */
+static void IGR_Load_Dashboard(void)
+{
+    char *dashboardArgv[] = {eec.IGRExitPath};
+    t_ExecData elf;
+    int result;
+
+    IGR_DIAG_COLOR(COLOR_MAGENTA); // Clean loader entry reached.
+
+    SifInitRpc(0);
+    result = SifInitIopHeap();
+    if (result < 0) {
+        IGR_DIAG_COLOR(COLOR_RED);
+        for (;;) {
+        }
+    }
+
+    result = SifLoadFileInit();
+    if (result < 0) {
+        IGR_DIAG_COLOR(COLOR_PURPLE);
+        for (;;) {
+        }
+    }
+
+    sbv_patch_disable_prefix_check();
+    IGR_DIAG_COLOR(COLOR_YELLOW);
+
+    // Restore the ROM memory-card stack required by the IOP-side ELF loader.
+    SifLoadModule("rom0:SIO2MAN", 0, NULL);
+    SifLoadModule("rom0:MCMAN", 0, NULL);
+    SifLoadModule("rom0:MCSERV", 0, NULL);
+
+    /*
+     * ee_core96 and its dedicated stack end at 0x000A7000. The emulation
+     * module staging area begins there and is no longer needed after the IOP
+     * reset. Clear it together with all stale game RAM before loading NHDDL,
+     * exactly as OPL clears everything above its resident loader boundary.
+     */
+    WipeUserMemory((void *)&_stack_end, (void *)GetMemorySize());
+    FlushCache(WRITEBACK_DCACHE);
+
+    IGR_DIAG_COLOR(COLOR_TEAL); // About to request the configured launcher.
+    elf.epc = 0;
+    elf.gp = 0;
+    result = SifLoadElf(eec.IGRExitPath, &elf);
+    if ((result == 0) && (elf.epc != 0)) {
+        IGR_DIAG_COLOR(COLOR_GREEN); // Launcher is resident; execute it.
+        SifLoadFileExit();
+        SifExitIopHeap();
+        SifExitRpc();
+        FlushCache(WRITEBACK_DCACHE);
+        FlushCache(INVALIDATE_ICACHE);
+        CleanExecPS2((void *)elf.epc, (void *)elf.gp, 1, dashboardArgv);
+    }
+
+    // A steady red screen now means the memory-card ELF load returned/faulted.
+    IGR_DIAG_COLOR(COLOR_RED);
+    SifLoadFileExit();
+    SifExitIopHeap();
+    SifExitRpc();
+    for (;;) {
+    }
+}
+
+/*
+ * Some games link libpad after their main ELF has started.  OPL retries from
+ * its syscall hooks, but a title can load the library without creating one of
+ * the narrow high-priority thread shapes that hook watches.  Once IGR has a
+ * safe post-ExecPS2 foothold, retry at low priority during the game's startup
+ * window.  Stop after 15 seconds so unsupported pad libraries do not cost CPU
+ * for the rest of a play session.
+ */
+static void IGR_Scanner_Thread(void *arg)
+{
+    int attempt;
+
+    (void)arg;
+    for (attempt = 0; attempt < 150 && !padOpen_hooked; attempt++) {
+        if (!disable_padOpen_hook) {
+            padOpen_hooked = Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_HOOK);
+            if (padOpen_hooked) {
+                FlushCache(WRITEBACK_DCACHE);
+                FlushCache(INVALIDATE_ICACHE);
+                break;
+            }
+        }
+        delay(100);
+    }
+
+    IGR_Scanner_Thread_ID = -1;
+    ExitDeleteThread();
+}
+
+// The IGR thread: sleeps until the VBLANK handler detects the combo, then
+// performs a clean IOP reset and relaunches the configured exit ELF.
+static void IGR_Thread(void *arg)
+{
+    (void)arg;
+    u32 cop0Perf;
+    struct t_SifDmaTransfer igrDma;
+
+    // Woken by the IGR interrupt handler on combo detect
+    SleepThread();
+
+    DPRINTF("IGR: thread woken, resetting to dashboard\n");
+
+    // These colors survive the game's frozen frame and identify the last
+    // completed reset stage on hardware. Successful resets only flash them.
+    IGR_DIAG_COLOR(COLOR_WHITE);
+
+    // The former Neutrino-specific synchronous shutdown RPC consistently
+    // returned and then left the raw reset submission frozen at the blue
+    // hardware checkpoint. Neutrino's FHI backend has no OPL DeviceLock /
+    // DeviceUnmount contract, so that RPC was not equivalent to OPL's even
+    // though it reused OPL's RPC number. At this point every game EE thread is
+    // already suspended and SIF channels 5/6/7 deliberately remain enabled.
+    // Give an already-submitted UDPFS/FHI transfer time to finish, then reset
+    // the IOP directly without injecting another RPC into the SIF command
+    // channel immediately beforehand.
+    IGR_DIAG_COLOR(COLOR_MAGENTA);
+    delay(250);
+    IGR_DIAG_COLOR(COLOR_BLUE);
+
+    /*
+     * Submit the OPL-style raw IOP reset inline. The prior builds called the
+     * resident Reset_Iop() function here; on hardware both reset inputs
+     * consistently stopped on this dark-blue checkpoint without reaching the
+     * function's first cyan store. The handler and this thread are therefore
+     * alive, but that separate call target is not dependable in every game.
+     * Keep the reset in this already-running resident function and use the
+     * original SIF syscall handlers saved before the game installed its own
+     * environment. As in OPL, SIF0 is deliberately not stopped.
+     */
+    IGR_DIAG_COLOR(COLOR_LBLUE);
+    delay(100);
+    _iop_reboot_count++;
+    memset(&IGR_Reset_Packet, 0, sizeof(IGR_Reset_Packet));
+    IGR_Reset_Packet.header.psize = sizeof(IGR_Reset_Packet);
+    IGR_Reset_Packet.header.cid = SIF_CMD_RESET_CMD;
+    IGR_Reset_Packet.arglen = 0;
+    IGR_Reset_Packet.mode = 0;
+
+    igrDma.src = &IGR_Reset_Packet;
+    /*
+     * This lookup happens in normal thread/user mode, so it must cross the
+     * syscall boundary. Old_SifGetReg is the raw kernel handler captured by
+     * Install_Kernel_Hooks(); calling it directly here jumps
+     * into a kernel-only routine from user mode and freezes at the light-blue
+     * checkpoint. OPL's Reset_Iop uses SifGetReg() here for the same reason.
+     * The saved Old_SifSetReg/Old_SifSetDma handlers below are safe because
+     * those calls occur only after ee_kmode_enter().
+     */
+    igrDma.dest = (void *)SifGetReg(SIF_SYSREG_SUBADDR);
+    igrDma.size = sizeof(IGR_Reset_Packet);
+    igrDma.attr = SIF_DMA_ERT | SIF_DMA_INT_O;
+    SifWriteBackDCache(&IGR_Reset_Packet, sizeof(IGR_Reset_Packet));
+
+    IGR_DIAG_COLOR(COLOR_WHITE);
+    DIntr();
+    ee_kmode_enter();
+    Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_BOOTEND);
+    while (!Old_SifSetDma(&igrDma, 1)) {
+        IGR_DIAG_COLOR(COLOR_RED);
+        ee_kmode_exit();
+        EIntr();
+        delay(1);
+        DIntr();
+        ee_kmode_enter();
+        Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_BOOTEND);
+    }
+    Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_SIFINIT);
+    Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_CMDINIT);
+    Old_SifSetReg(SIF_SYSREG_RPCINIT, 0);
+    Old_SifSetReg(SIF_SYSREG_SUBADDR, (int)NULL);
+    ee_kmode_exit();
+    EIntr();
+
+    IGR_DIAG_COLOR(COLOR_YELLOW);
+    Remove_Kernel_Hooks();
+    IGR_DIAG_COLOR(COLOR_PURPLE);
+
+    // Some games (notably GT4/GTA) replace the EE memory map. Restore the
+    // standard TLB before touching/loading application memory, matching OPL's
+    // reset path and current ps2sdk ExecPS2 behaviour.
+    InitializeTLB();
+    IGR_DIAG_COLOR(COLOR_TEAL);
+
+    // Games such as GT4/GTA leave the COP0 performance counter running; an
+    // overflow during the next application can raise an exception. Restore
+    // the other resident hooks before loading the dashboard as OPL IGR does.
+    cop0Perf = GetCop0(25);
+    if (cop0Perf & 0x80000000) {
+        __asm__ volatile(
+            "mfc0 $3, $25\n"
+            "lui  $2, 0x8000\n"
+            "or   $3, $3, $2\n"
+            "xor  $3, $3, $2\n"
+            "mtc0 $3, $25\n"
+            "sync.p\n"
+            :
+            :
+            : "$2", "$3", "memory");
+    }
+    if (eec.GsmVideoMode != EECORE_GSM_VMODE_NONE)
+        DisableGSM();
+    if (eec.CheatList != NULL)
+        DisableCheats();
+    IGR_DIAG_COLOR(COLOR_OLIVE);
+
+    // Wait for the raw reset submitted above to finish.
+    while (!SifIopSync()) {
+    }
+    IGR_DIAG_COLOR(COLOR_GREEN);
+
+    /*
+     * Do not initialize memory-card RPC or load the dashboard from this old
+     * game thread. Enter a clean EE execution context first, matching OPL's
+     * IGR_Exit/t_loadElf handoff. Hooks were removed above, so this reaches
+     * the original ExecPS2 implementation rather than Neutrino's game hook.
+     */
+    IGR_DIAG_COLOR(COLOR_WHITE);
+
+    /*
+     * Match OPL's IGR_Exit handoff exactly here. Neutrino's CleanExecPS2
+     * wrapper is not suitable for this first transition because it
+     * clears the caller's register set before entering the kernel and real
+     * hardware stopped after the game disappeared, leaving a black screen
+     * before the loader's first checkpoint.  ExecPS2 already creates the
+     * clean thread/peripheral context this resident loader needs.  Keep
+     * CleanExecPS2 only for the second transition, after NHDDL has been loaded
+     * into memory, where it is Neutrino's established ELF-launch path.
+     */
+    if (eec.IGRExitPath[0] != '\0')
+        ExecPS2((void *)IGR_Load_Dashboard, &_gp, 0, NULL);
+
+    // Match upstream OPL: no configured exit ELF returns to the PS2 Browser.
+    Exit(0);
+}
+
+// VBLANK-END interrupt handler: watches the game's pad buffer for the combo.
+static int IGR_Intc_Handler(int cause)
+{
+    (void)cause;
+    int pad_index;
+    int liveness_sampled = 0;
+    int any_pad_live = 0;
+
+    for (pad_index = 0; pad_index < IGR_PHYSICAL_PAD_COUNT; pad_index++) {
+        paddata_t *pad = &Pad_Data[pad_index];
+
+        if (pad->pad_buf != NULL) {
+            u8 *pad_buf = (u8 *)UNCACHED_SEG(pad->pad_buf);
+            u8 pad_pos_state = pad_buf[pad->pos_state];
+            u8 pad_pos_frame = pad_buf[pad->pos_frame];
+            u8 pad_pos_combo1 = pad_buf[pad->pos_combo1];
+            u8 pad_pos_combo2 = pad_buf[pad->pos_combo2];
+
+            if (((pad->libpad == IGR_LIBPAD) && (pad_pos_state == IGR_PAD_STABLE_V1)) ||
+                ((pad->libpad == IGR_LIBPAD2) && (pad_pos_state == IGR_PAD_STABLE_V2))) {
+                // Track each socket independently. A stale controller-1
+                // buffer must not hide a live controller-2 buffer (or vice
+                // versa) and spuriously re-arm the code scanner.
+                if (pad->vb_count++ >= 10) {
+                    pad->live = (pad_pos_frame != pad->prev_frame);
+                    if (pad->live)
+                        pad->prev_frame = pad_pos_frame;
+                    pad->vb_count = 0;
+                    liveness_sampled = 1;
+                }
+
+                if (pad_pos_combo1 == IGR_COMBO_R1_L1_R2_L2 &&
+                    pad_pos_combo2 == IGR_COMBO_START_SELECT)
+                    IGR_Reset_Requested = pad_pos_combo2;
+            }
+        } else {
+            pad->live = 0;
+        }
+
+        if (pad->live)
+            any_pad_live = 1;
+    }
+
+    if (liveness_sampled)
+        padOpen_hooked = any_pad_live;
+
+    // Catch the console's front-panel reset/power event even for titles whose
+    // libpad implementation could not be hooked. Cancel the hardware's normal
+    // poweroff command and route a tap through the same clean reset path as
+    // the controller combo.
+    if (eec.IGRFlags & EECORE_IGR_FLAG_POWER_BUTTON_RESET) {
+        ee_kmode_enter();
+        if ((*CDVD_R_NDIN & 0x20) && (*CDVD_R_POFF & 0x04)) {
+            *CDVD_R_SDIN = 0x00;
+            *CDVD_R_SCMD = 0x1B;
+            IGR_Reset_Requested = IGR_COMBO_START_SELECT;
+        }
+        ee_kmode_exit();
+    }
+
+    if (IGR_Reset_Requested != 0x00) {
+        int i;
+        int wake_result;
+        ee_thread_status_t worker_status;
+        u32 gs_reset_polls;
+
+        // Some games terminate/delete threads they did not create and then
+        // reuse the ID. Never freeze the game unless the saved ID still
+        // describes our exact resident worker and a state that can be woken.
+        if ((IGR_Thread_ID <= 0) || (IGR_Thread_ID >= 256) ||
+            (iReferThreadStatus(IGR_Thread_ID, &worker_status) < 0) ||
+            (worker_status.func != IGR_Thread) ||
+            (worker_status.stack != (void *)IGR_Stack) ||
+            (worker_status.stack_size != IGR_STACK_SIZE)) {
+            IGR_Reset_Requested = 0x00;
+            ExitHandler();
+            return 0;
+        }
+
+        if ((worker_status.status == THS_WAITSUSPEND) ||
+            (worker_status.status == THS_SUSPEND)) {
+            if (iResumeThread(IGR_Thread_ID) < 0) {
+                IGR_Reset_Requested = 0x00;
+                ExitHandler();
+                return 0;
+            }
+        } else if (!(((worker_status.status == THS_WAIT) &&
+                      (worker_status.waitType == TSW_SLEEP)) ||
+                     (worker_status.status == THS_READY))) {
+            IGR_Reset_Requested = 0x00;
+            ExitHandler();
+            return 0;
+        }
+
+        // Interrupt dispatch cannot run the worker until ExitHandler(). Wake
+        // it first so a failed wake leaves the game intact instead of frozen
+        // after DMA, GS, and every other thread have already been stopped.
+        wake_result = iWakeupThread(IGR_Thread_ID);
+        if (wake_result < 0) {
+            IGR_Reset_Requested = 0x00;
+            ExitHandler();
+            return 0;
+        }
+
+        // Bring the EE to a safe state before waking the IGR thread.
+        // (Mirrors OPL: stop DMA, reset GS, ResetEE from the handler.)
+        asm volatile("sync.l\n");
+
+        u32 dmaEnableR = *IGR_R_D_ENABLER;
+        *IGR_R_D_ENABLEW = dmaEnableR | 0x10000;
+        (void)*IGR_R_D_CTRL;
+        (void)*IGR_R_D_STAT;
+        *IGR_R_D0_CHCR = 0;
+        *IGR_R_D1_CHCR = 0;
+        *IGR_R_D2_CHCR = 0;
+        *IGR_R_D3_CHCR = 0;
+        *IGR_R_D4_CHCR = 0;
+        *IGR_R_D8_CHCR = 0;
+        *IGR_R_D9_CHCR = 0;
+        *IGR_R_D_ENABLEW = dmaEnableR;
+
+        asm volatile("sync.l\n");
+
+        *IGR_R_GS_CSR = 0x100; // Reset GS
+        asm volatile("sync.l\n");
+
+        if (_strcmp(eec.GameID, "SLUS_200.70") == 0) {
+            // Q-Ball can leave the GS RESET bit asserted forever. ResetEE
+            // immediately below resets the same peripheral state, so bound
+            // this one title's poll and fail forward to the resident worker.
+            gs_reset_polls = 0x100000;
+            while ((*IGR_R_GS_CSR & 0x100) && --gs_reset_polls) {
+            }
+        } else {
+            // Preserve the hardware-proven production sequence for titles
+            // that have never exhibited Q-Ball's stuck-GS condition.
+            while (*IGR_R_GS_CSR & 0x100) {
+            }
+        }
+
+        iResetEE(0x7F);
+
+        // Suspend every thread except idle and our IGR thread
+        for (i = 1; i < 256; i++) {
+            if (i != IGR_Thread_ID)
+                iSuspendThread(i);
+        }
+
+        iChangeThreadPriority(IGR_Thread_ID, 0);
+        // Retain the proven post-takeover wake as well. The earlier wake is a
+        // fail-safe validation; this second one preserves the established
+        // production ordering after ResetEE and thread suspension.
+        iWakeupThread(IGR_Thread_ID);
+    }
+
+    ExitHandler();
+    return 0;
+}
+
+static int IGR_Pad_Index(int port, int slot)
+{
+    if ((slot == 0) && (port >= 0) && (port < IGR_PHYSICAL_PAD_COUNT))
+        return port;
+
+    return -1;
+}
+
+// Sets pad-buffer field offsets for the detected libpad version.
+static void Set_libpad_Params(int pad_index, void *addr)
+{
+    paddata_t *pad;
+
+    if ((pad_index < 0) || (pad_index >= IGR_PHYSICAL_PAD_COUNT))
+        return;
+
+    pad = &Pad_Data[pad_index];
+    DI();
+
+    // Publish pad_buf last so the VBLANK handler can never observe a new
+    // pointer paired with partially initialized offsets or library metadata.
+    pad->pad_buf = NULL;
+    pad->libpad = IGR_Libpad;
+    pad->libversion = IGR_Libversion;
+    pad->vb_count = 0;
+    pad->combo_type = 0x00;
+    pad->prev_frame = 0x00;
+    pad->live = 0;
+
+    if (pad->libpad == IGR_LIBPAD) {
+        if (pad->libversion >= 0x0160) {
+            pad->pos_combo1 = 3;
+            pad->pos_combo2 = 2;
+            pad->pos_state = 112;
+            pad->pos_frame = 88;
+        } else {
+            pad->pos_combo1 = 11;
+            pad->pos_combo2 = 10;
+            pad->pos_state = 4;
+            pad->pos_frame = 0;
+        }
+    } else if (pad->libpad == IGR_LIBPAD2) {
+        pad->pos_combo1 = 29;
+        pad->pos_combo2 = 28;
+        pad->pos_state = 4;
+        pad->pos_frame = 124;
+    }
+
+    pad->pad_buf = addr;
+
+    EI();
+}
+
+void Install_IGR(void)
+{
+    ee_thread_t thread_param;
+    int start_result;
+
+    if (IGR_Thread_ID < 0) {
+        // Initialize state only when creating a new post-ExecPS2 IGR instance.
+        // Install_IGR is intentionally safe to call repeatedly from syscall
+        // lifecycle hooks so the physical button does not depend on libpad.
+        memset(Pad_Data, 0, sizeof(Pad_Data));
+        IGR_Reset_Requested = 0x00;
+
+        thread_param.gp_reg = &_gp;
+        thread_param.func = IGR_Thread;
+        thread_param.stack = (void *)IGR_Stack;
+        thread_param.stack_size = IGR_STACK_SIZE;
+        thread_param.initial_priority = 127;
+        thread_param.attr = 0;
+        thread_param.option = 0;
+        IGR_Thread_ID = CreateThread(&thread_param);
+        if (IGR_Thread_ID >= 0) {
+            start_result = StartThread(IGR_Thread_ID, NULL);
+            if (start_result < 0) {
+                DeleteThread(IGR_Thread_ID);
+                IGR_Thread_ID = -1;
+            }
+        }
+    }
+
+    // Never install a destructive reset interrupt without a valid worker.
+    if ((IGR_Thread_ID > 0) && (IGR_Intc_ID < 0)) {
+        IGR_Intc_ID = AddIntcHandler(kINTC_VBLANK_END, IGR_Intc_Handler, 0);
+        if (IGR_Intc_ID >= 0)
+            EnableIntc(kINTC_VBLANK_END);
+    }
+
+    if (!padOpen_hooked && IGR_Scanner_Thread_ID < 0) {
+        thread_param.gp_reg = &_gp;
+        thread_param.func = IGR_Scanner_Thread;
+        thread_param.stack = (void *)IGR_Scanner_Stack;
+        thread_param.stack_size = IGR_SCANNER_STACK_SIZE;
+        thread_param.initial_priority = 127;
+        thread_param.attr = 0;
+        thread_param.option = 0;
+        IGR_Scanner_Thread_ID = CreateThread(&thread_param);
+        if (IGR_Scanner_Thread_ID >= 0)
+            StartThread(IGR_Scanner_Thread_ID, NULL);
+    }
+}
+
+void Reset_Padhook(void)
+{
+    IGR_Intc_ID = -1;
+    IGR_Thread_ID = -1;
+    IGR_Scanner_Thread_ID = -1;
+    IGR_Reset_Requested = 0x00;
+    memset(Pad_Data, 0, sizeof(Pad_Data));
+    padOpen_hooked = 0;
+}
+
+// Hook for libpad scePadPortOpen: re-checks the hook and installs IGR.
+static int Hook_scePadPortOpen(int port, int slot, void *addr)
+{
+    int ret;
+    int pad_index = IGR_Pad_Index(port, slot);
+
+    if (pad_index >= 0)
+        Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_CHECK);
+
+    ret = scePadPortOpen(port, slot, addr);
+
+    if (pad_index >= 0) {
+        Install_IGR();
+        Set_libpad_Params(pad_index, addr);
+    }
+
+    return ret;
+}
+
+// Hook for libpad2 scePad2CreateSocket.
+static int Hook_scePad2CreateSocket(pad2socketparam_t *SocketParam, void *addr)
+{
+    int ret;
+    int pad_index = (SocketParam == NULL) ? 0 :
+                    IGR_Pad_Index(SocketParam->port, SocketParam->slot);
+
+    if (pad_index >= 0)
+        Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_CHECK);
+
+    ret = scePad2CreateSocket(SocketParam, addr);
+
+    if (pad_index >= 0) {
+        Install_IGR();
+        Set_libpad_Params(pad_index, addr);
+    }
+
+    return ret;
+}
+
+int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode)
+{
+    u32 *ptr, *ptr2;
+    u32 inst, fncall;
+    u32 mem_size, mem_size2;
+    u32 pattern[1], mask[1];
+    int i, found, patched;
+
+    pattern_t padopen_patterns[NB_PADOPEN_PATTERN] = {
+        {padPortOpenpattern0, padPortOpenpattern0_mask, sizeof(padPortOpenpattern0), 1, 0x0211},
+        {pad2CreateSocketpattern0, pad2CreateSocketpattern0_mask, sizeof(pad2CreateSocketpattern0), 2, 0x0200},
+        {pad2CreateSocketpattern1, pad2CreateSocketpattern1_mask, sizeof(pad2CreateSocketpattern1), 2, 0x0200},
+        {pad2CreateSocketpattern2, pad2CreateSocketpattern2_mask, sizeof(pad2CreateSocketpattern2), 2, 0x0200},
+        {padPortOpenpattern1, padPortOpenpattern1_mask, sizeof(padPortOpenpattern1), 1, 0x0210},
+        {padPortOpenpattern2, padPortOpenpattern2_mask, sizeof(padPortOpenpattern2), 1, 0x0160},
+        {padPortOpenpattern3, padPortOpenpattern3_mask, sizeof(padPortOpenpattern3), 1, 0x0150}};
+
+    found = 0;
+    patched = 0;
+
+    for (i = 0; i < NB_PADOPEN_PATTERN; i++) {
+        ptr = (u32 *)mem_start;
+        while (ptr) {
+            mem_size = mem_end - (u32)ptr;
+
+            ptr = find_pattern_with_mask(ptr, mem_size, padopen_patterns[i].pattern, padopen_patterns[i].mask, padopen_patterns[i].size);
+            if (ptr) {
+                DPRINTF("IGR: found padopen pattern%d at 0x%08x mode=%d\n", i, (int)ptr, mode);
+                found = 1;
+
+                if (padopen_patterns[i].type == IGR_LIBPAD)
+                    scePadPortOpen = (void *)ptr;
+                else
+                    scePad2CreateSocket = (void *)ptr;
+
+                if (mode == PADOPEN_HOOK) {
+                    // Match both J and JAL to the located function
+                    inst = 0x08000000 | (0x03ffffff & ((u32)ptr >> 2));
+                    pattern[0] = inst;
+                    mask[0] = 0xfbffffff;
+
+                    ptr2 = (u32 *)mem_start;
+                    while (ptr2) {
+                        mem_size2 = (u32)((u8 *)mem_end - (u8 *)ptr2);
+                        ptr2 = find_pattern_with_mask(ptr2, mem_size2, pattern, mask, sizeof(pattern));
+                        if (ptr2) {
+                            patched = 1;
+                            fncall = (u32)ptr2;
+                            inst = (ptr2[0] & 0xfc000000);
+                            if (padopen_patterns[i].type == IGR_LIBPAD)
+                                inst |= 0x03ffffff & ((u32)Hook_scePadPortOpen >> 2);
+                            else
+                                inst |= 0x03ffffff & ((u32)Hook_scePad2CreateSocket >> 2);
+                            _sw(inst, fncall);
+                            IGR_Libpad = padopen_patterns[i].type;
+                            IGR_Libversion = padopen_patterns[i].version;
+                        }
+                    }
+
+                    // Fallback: patch pointer-to-function (JALR use)
+                    if (!patched) {
+                        pattern[0] = (u32)ptr;
+                        mask[0] = 0xffffffff;
+                        ptr2 = (u32 *)mem_start;
+                        while (ptr2) {
+                            mem_size2 = (u32)((u8 *)mem_end - (u8 *)ptr2);
+                            ptr2 = find_pattern_with_mask(ptr2, mem_size2, pattern, mask, sizeof(pattern));
+                            if (ptr2) {
+                                patched = 1;
+                                fncall = (u32)ptr2;
+                                if (padopen_patterns[i].type == IGR_LIBPAD)
+                                    inst = (u32)Hook_scePadPortOpen;
+                                else
+                                    inst = (u32)Hook_scePad2CreateSocket;
+                                _sw(inst, fncall);
+                                IGR_Libpad = padopen_patterns[i].type;
+                                IGR_Libversion = padopen_patterns[i].version;
+                            }
+                        }
+                    }
+                } else {
+                    break; // PADOPEN_CHECK: found is enough
+                }
+
+                ptr += (padopen_patterns[i].size >> 2);
+            }
+        }
+
+        if (patched == 1 || (mode == PADOPEN_CHECK && found == 1))
+            break;
+    }
+
+    return patched;
+}

--- a/ee/ee_core/src/tlb.c
+++ b/ee/ee_core/src/tlb.c
@@ -1,0 +1,152 @@
+#include <kernel.h>
+
+#include "tlb.h"
+
+static int InitTLB32MB(void);
+
+void InitializeTLB(void)
+{
+    if (GetMemorySize() == 0x2000000)
+        InitTLB32MB();
+    else
+        _InitTLB();
+}
+
+static int SetTLBEntry(unsigned int index, unsigned int pageMask, unsigned int entryHi, unsigned int entryLo0, unsigned int entryLo1)
+{
+    if (index >= 0x30)
+        return -1;
+
+    __asm__ volatile(
+        "mtc0 %0, $0\n"
+        "mtc0 %1, $5\n"
+        "mtc0 %2, $10\n"
+        "mtc0 %3, $2\n"
+        "mtc0 %4, $3\n"
+        "sync.p\n"
+        "tlbwi\n"
+        "sync.p\n"
+        :
+        : "r"(index), "r"(pageMask), "r"(entryHi), "r"(entryLo0), "r"(entryLo1));
+
+    return index;
+}
+
+struct TLBEntry
+{
+    unsigned int pageMask;
+    unsigned int entryHi;
+    unsigned int entryLo0;
+    unsigned int entryLo1;
+};
+
+struct TLBInfo
+{
+    unsigned int numKernelEntries;
+    unsigned int numDefaultEntries;
+    unsigned int numExtendedEntries;
+    unsigned int numWiredEntries;
+    const struct TLBEntry *kernelEntries;
+    const struct TLBEntry *defaultEntries;
+    const struct TLBEntry *extendedEntries;
+};
+
+#define TLB_NUM_KERNEL_ENTRIES 0x0D
+#define TLB_NUM_DEFAULT_ENTRIES 0x12
+#define TLB_NUM_EXTENDED_ENTRIES 0x08
+
+#if (TLB_NUM_KERNEL_ENTRIES + TLB_NUM_DEFAULT_ENTRIES + TLB_NUM_EXTENDED_ENTRIES >= 0x31)
+#error TLB overflow
+#endif
+
+static const struct TLBEntry kernelTLB[TLB_NUM_KERNEL_ENTRIES] = {
+    {0x00000000, 0x70000000, 0x80000007, 0x00000007},
+    {0x00006000, 0xFFFF8000, 0x00001E1F, 0x00001F1F},
+    {0x00000000, 0x10000000, 0x00400017, 0x00400053},
+    {0x00000000, 0x10002000, 0x00400097, 0x004000D7},
+    {0x00000000, 0x10004000, 0x00400117, 0x00400157},
+    {0x00000000, 0x10006000, 0x00400197, 0x004001D7},
+    {0x00000000, 0x10008000, 0x00400217, 0x00400257},
+    {0x00000000, 0x1000A000, 0x00400297, 0x004002D7},
+    {0x00000000, 0x1000C000, 0x00400313, 0x00400357},
+    {0x00000000, 0x1000E000, 0x00400397, 0x004003D7},
+    {0x0001E000, 0x11000000, 0x00440017, 0x00440415},
+    {0x0001E000, 0x12000000, 0x00480017, 0x00480415},
+    {0x01FFE000, 0x1E000000, 0x00780017, 0x007C0017}};
+
+static const struct TLBEntry defaultTLB[TLB_NUM_DEFAULT_ENTRIES] = {
+    {0x0007E000, 0x00080000, 0x0000201F, 0x0000301F},
+    {0x0007E000, 0x00100000, 0x0000401F, 0x0000501F},
+    {0x0007E000, 0x00180000, 0x0000601F, 0x0000701F},
+    {0x001FE000, 0x00200000, 0x0000801F, 0x0000C01F},
+    {0x001FE000, 0x00400000, 0x0001001F, 0x0001401F},
+    {0x001FE000, 0x00600000, 0x0001801F, 0x0001C01F},
+    {0x007FE000, 0x00800000, 0x0002001F, 0x0003001F},
+    {0x007FE000, 0x01000000, 0x0004001F, 0x0005001F},
+    {0x007FE000, 0x01800000, 0x0006001F, 0x0007001F},
+    {0x0007E000, 0x20080000, 0x00002017, 0x00003017},
+    {0x0007E000, 0x20100000, 0x00004017, 0x00005017},
+    {0x0007E000, 0x20180000, 0x00006017, 0x00007017},
+    {0x001FE000, 0x20200000, 0x00008017, 0x0000C017},
+    {0x001FE000, 0x20400000, 0x00010017, 0x00014017},
+    {0x001FE000, 0x20600000, 0x00018017, 0x0001C017},
+    {0x007FE000, 0x20800000, 0x00020017, 0x00030017},
+    {0x007FE000, 0x21000000, 0x00040017, 0x00050017},
+    {0x007FE000, 0x21800000, 0x00060017, 0x00070017}};
+
+static const struct TLBEntry extendedTLB[TLB_NUM_EXTENDED_ENTRIES] = {
+    {0x0007E000, 0x30100000, 0x0000403F, 0x0000503F},
+    {0x0007E000, 0x30180000, 0x0000603F, 0x0000703F},
+    {0x001FE000, 0x30200000, 0x0000803F, 0x0000C03F},
+    {0x001FE000, 0x30400000, 0x0001003F, 0x0001403F},
+    {0x001FE000, 0x30600000, 0x0001803F, 0x0001C03F},
+    {0x007FE000, 0x30800000, 0x0002003F, 0x0003003F},
+    {0x007FE000, 0x31000000, 0x0004003F, 0x0005003F},
+    {0x007FE000, 0x31800000, 0x0006003F, 0x0007003F}};
+
+static struct TLBInfo tlbInfo = {
+    TLB_NUM_KERNEL_ENTRIES,
+    TLB_NUM_DEFAULT_ENTRIES,
+    TLB_NUM_EXTENDED_ENTRIES,
+    0,
+    kernelTLB,
+    defaultTLB,
+    extendedTLB};
+
+static int InitTLB32MB(void)
+{
+    unsigned int i;
+    unsigned int numEntries;
+    unsigned int value;
+    unsigned int endIndex;
+    const struct TLBEntry *entry;
+
+    __asm__ volatile(
+        "mtc0 $zero, $6\n"
+        "sync.p\n");
+
+    for (i = 0, entry = tlbInfo.kernelEntries; i < tlbInfo.numKernelEntries; i++, entry++)
+        SetTLBEntry(i, entry->pageMask, entry->entryHi, entry->entryLo0, entry->entryLo1);
+
+    entry = tlbInfo.defaultEntries;
+    endIndex = tlbInfo.numDefaultEntries + i;
+    for (; i < endIndex; i++, entry++)
+        SetTLBEntry(i, entry->pageMask, entry->entryHi, entry->entryLo0, entry->entryLo1);
+
+    tlbInfo.numWiredEntries = numEntries = i;
+    __asm__ volatile(
+        "mtc0 %0, $6\n"
+        "sync.p\n"
+        :
+        : "r"(numEntries));
+
+    entry = tlbInfo.extendedEntries;
+    endIndex = tlbInfo.numExtendedEntries + i;
+    for (; i < endIndex; i++, entry++, numEntries++)
+        SetTLBEntry(i, entry->pageMask, entry->entryHi, entry->entryLo0, entry->entryLo1);
+
+    for (value = 0xE0000000 + (numEntries << 13); i < 0x30; i++, value += 0x2000)
+        SetTLBEntry(i, 0, value, 0, 0);
+
+    return numEntries;
+}

--- a/ee/ee_core/src/util.c
+++ b/ee/ee_core/src/util.c
@@ -25,6 +25,26 @@ void _strcpy(char *dst, const char *src)
     strncpy(dst, src, strlen(src) + 1);
 }
 
+/*
+  strlcpy() for ee_core.
+
+  The ee_core links a minimal lib set (-lpatches -lkernel -lgcc, no libc).
+  Newer ps2sdk builds reference strlcpy from libkernel's LoadExecPS2, which
+  is otherwise undefined here (stock ee_core fails to link the same way
+  against the current toolchain). Provide it locally.
+*/
+unsigned int strlcpy(char *dst, const char *src, unsigned int size)
+{
+    unsigned int srclen = strlen(src);
+    if (size != 0) {
+        unsigned int copylen = (srclen < size - 1) ? srclen : size - 1;
+        for (unsigned int i = 0; i < copylen; i++)
+            dst[i] = src[i];
+        dst[copylen] = '\0';
+    }
+    return srclen;
+}
+
 /* Do not link to strcat() from libc */
 void _strcat(char *dst, const char *src)
 {

--- a/ee/loader/Makefile
+++ b/ee/loader/Makefile
@@ -1,7 +1,7 @@
 GIT_TAG = $(shell git describe --tags --exclude=latest)
 
 EE_OBJS = main.o modlist.o config.o fhi_config.o xparam.o patch.o ioprp.o tomlc17.o iso_cnf.o
-EE_LIBS = -lfileXio -lpatches
+EE_LIBS = -lfileXio -lpatches -ldebug
 EE_CFLAGS = -DGIT_TAG=\"$(GIT_TAG)\"
 
 EE_NEWLIB_NANO = 1

--- a/ee/loader/config/compat.toml
+++ b/ee/loader/config/compat.toml
@@ -43,7 +43,8 @@ cdvdman.fs_sectors = 8
 #eecore.cheats = [0x2012AB00, 0x00000009]
 
 # EECORE: compatibility flags
-# - UNHOOK = MODE3: Unhook syscalls
+# - UNHOOK      = MODE3: Unhook syscalls
+# - DISABLE_IGR = MODE6: Do not hook the game's controller library
 #eecore.flags = ["UNHOOK"]
 
 # EECORE: iop reboot mode:
@@ -90,8 +91,9 @@ eecore.irm = [2, 2, 0] # Normal mode (2 IOP reboots)
 
 # EECORE: module base address
 # This is where all IOP modules are stored
-eecore.mod_base = 0x95000
-#eecore.mod_base = 0xA7000
+# Match the alternate ee_core96 linker layout: core 0x96000-0xA6000,
+# stack 0xA6000-0xA7000, then the IOP module table.
+eecore.mod_base = 0xA7000
 
 # ---------------------------------------------------------------------------
 # Compatibility modes from the command line
@@ -102,7 +104,7 @@ MODE2 = {name = "Compat MODE2: Sync reads (sceCdRead)",        cdvdman.flags = [
 MODE3 = {name = "Compat MODE3: Unhook syscalls",               eecore.flags  = ["UNHOOK"]}
 MODE4 = {name = "Compat MODE4: NOP (user configurable)"}
 MODE5 = {name = "Compat MODE5: Emulate DVD-DL",                cdvdman.flags = ["DVD_DL"]}
-MODE6 = {name = "Compat MODE6: NOP (user configurable)"}
+MODE6 = {name = "Compat MODE6: Disable in-game reset",        eecore.flags  = ["DISABLE_IGR"]}
 MODE7 = {name = "Compat MODE7: Fix game buffer overrun",       depends = ["p-membo"]}
 MODE8 = {name = "Compat MODE8: NOP (user configurable)"}
 
@@ -128,6 +130,7 @@ MODE9 = {name = "Compat MODE9: NOP"}
 #"SCES_524.24" = {name = "Ace Combat Squadron Leader",            depends = ["p-membo"]}
 #"SLUS_208.51" = {name = "Ace Combat 5 The Unsung War",           depends = ["p-membo"]}
 "SLES_504.86" = {name = "Splashdown",                            depends = ["p-membo2k"]}
+"SLUS_202.62" = {name = "EA Sports Rugby",                       eecore.flags = ["DISABLE_IGR"]}
 "SLUS_202.67" = {name = "Dot Hack Part 1 - Infection",           depends = ["p-membo2k"]}
 "SLES_504.46" = {name = "Shadow Man: 2econd Coming",             depends = ["p-membo2k"]}
 "SLUS_204.13" = {name = "Shadow Man: 2econd Coming",             depends = ["p-membo2k"]}

--- a/ee/loader/config/system.toml
+++ b/ee/loader/config/system.toml
@@ -17,9 +17,15 @@ default_elf = "auto"
 #default_cfg = ""
 default_dbc = false
 default_logo = false
+# Optional in-game-reset destination. Empty returns to the PS2 Browser.
+# NHDDL supplies its actual launch path on the command line.
+#default_igr_path = "mc0:/path/to/launcher.elf"
+# A short power-button press normally powers off. Enable only when a launcher
+# deliberately wants it routed through the same restart path as the pad combo.
+default_igr_power = false
 
 # EE_CORE configuration
-eecore.elf = "ee_core.elf"
+eecore.elf = "ee_core96.elf"
 
 # Modules to load in emulation environment
 [[module]]

--- a/ee/loader/src/config.c
+++ b/ee/loader/src/config.c
@@ -267,6 +267,7 @@ int load_config_eecore(toml_datum_t t)
             v = arr.u.arr.elem[i];
             if (v.type == TOML_STRING) {
                 if (!strcmp(v.u.s, "UNHOOK")) sys.eecore.flags |= EECORE_FLAG_UNHOOK;
+                else if (!strcmp(v.u.s, "DISABLE_IGR")) sys.eecore.flags |= EECORE_FLAG_DISABLE_IGR;
             }
         }
     }
@@ -375,8 +376,10 @@ int load_config(toml_datum_t t)
     toml_string_in_overwrite(t, "default_gc",     &sys.sGC);
     toml_string_in_overwrite(t, "default_gsm",    &sys.sGSM);
     toml_string_in_overwrite(t, "default_cfg",    &sys.sCFGFile);
+    toml_string_in_overwrite(t, "default_igr_path", &sys.sIGRPath);
     toml_bool_in_overwrite  (t, "default_dbc",    &sys.bDebug);
     toml_bool_in_overwrite  (t, "default_logo",   &sys.bLogo);
+    toml_bool_in_overwrite  (t, "default_igr_power", &sys.bIGRPowerReset);
 
     load_config_eecore (toml_get(t, "eecore"));
     load_config_cdvdman(toml_get(t, "cdvdman"));

--- a/ee/loader/src/config.h
+++ b/ee/loader/src/config.h
@@ -29,9 +29,11 @@ struct SSystemSettings {
     char *sGC;
     char *sGSM;
     char *sCFGFile;
+    char *sIGRPath;
     int bDebug;
     int bLogo;
     int bQuickBoot;
+    int bIGRPowerReset;
 
     struct {
         // CDVDMAN settings

--- a/ee/loader/src/main.c
+++ b/ee/loader/src/main.c
@@ -17,6 +17,7 @@ _off64_t lseek64 (int __filedes, _off64_t __offset, int __whence); // should be 
 #include <sifrpc.h>
 #include <iopheap.h>
 #include <sbv_patches.h>
+#include <debug.h>
 
 // Neutrino EE_CORE
 #include "../../../common/include/eecore_config.h"
@@ -50,6 +51,16 @@ void _libcglue_timezone_update() {}; // Disable timezone update
 void _libcglue_rtc_update() {}; // Disable rtc update
 
 struct SModule mod_ee_core;
+
+static __attribute__((noreturn)) void diag_halt(const char *message)
+{
+    init_scr();
+    scr_clear();
+    scr_printf("Neutrino launch failed\n\n%s\n", message);
+    scr_printf("\nRestart the console to return to your launcher.\n");
+    for (;;)
+        SleepThread();
+}
 
 void print_usage()
 {
@@ -130,6 +141,8 @@ void print_usage()
     printf("  -cwd=<path>       Change working directory\n");
     printf("\n");
     printf("  -cfg=<file>       Load extra user/game specific config file (without .toml extension)\n");
+    printf("  -igr-path=<file>  In-game-reset destination (empty returns to PS2 Browser)\n");
+    printf("  -igr-power=<0|1>  Route a short power-button press through in-game reset\n");
     printf("\n");
     printf("  -dbc              Enable debug colors\n");
     printf("  -logo             Enable logo (adds rom0:PS2LOGO to arguments)\n");
@@ -186,6 +199,10 @@ static int parse_cmdline_args(int argc, char *argv[], int *out_iELFArgcStart)
             sys.sGSM = &argv[i][5];
         else if (!strncmp(argv[i], "-cfg=", 5))
             sys.sCFGFile = &argv[i][5];
+        else if (!strncmp(argv[i], "-igr-path=", 10))
+            sys.sIGRPath = &argv[i][10];
+        else if (!strncmp(argv[i], "-igr-power=", 11))
+            sys.bIGRPowerReset = (argv[i][11] != '0');
         else if (!strncmp(argv[i], "-cwd=", 5))
             continue; // already handled before config loading
         else if (!strncmp(argv[i], "-dbc", 4))
@@ -702,7 +719,7 @@ int main(int argc, char *argv[])
     }
     if (modlist_load(&drv.mod, (sys.bQuickBoot == 0) ? (MOD_ENV_LE | MOD_ENV_EE) : MOD_ENV_EE) < 0) {
         printf("ERROR: failed to load drv.mod\n");
-        return -1;
+        diag_halt("Could not stage driver modules from memory card");
     }
 
     /*
@@ -738,16 +755,26 @@ int main(int argc, char *argv[])
         for (i = 0; i < drv.mod.count; i++) {
             struct SModule *pm = &drv.mod.mod[i];
             if (pm->env & MOD_ENV_LE) {
-                if (module_start(pm) < 0)
-                    return -1;
+                if (module_start(pm) < 0) {
+                    diag_halt("Load-environment module failed");
+                }
             }
         }
-        if (modlist_get_by_name(&drv.mod, "fileXio.irx") != NULL)
-            fileXioInit();
+        if (modlist_get_by_name(&drv.mod, "fileXio.irx") != NULL) {
+            int fileXioResult = fileXioInit();
+            if (fileXioResult < 0)
+                diag_halt("fileXio RPC initialization failed");
+        }
     }
 
     // Load EE_CORE settings
     struct ee_core_data *set_ee_core = module_get_settings(&mod_ee_core);
+    if ((set_ee_core == NULL) ||
+        ((uint8_t *)set_ee_core + sizeof(*set_ee_core) >
+         (uint8_t *)mod_ee_core.pData + mod_ee_core.iSize) ||
+        (set_ee_core->IGRABIMagic != EECORE_IGR_ABI_MAGIC)) {
+        diag_halt("ee_core is incompatible with this Neutrino loader");
+    }
 
     // Detect active FHI backing store and zero its settings struct
     int fhi_active = (fhi_config_init(&drv.mod) == 0);
@@ -786,7 +813,7 @@ int main(int argc, char *argv[])
         }
 
         if (setup_dvd_iso(sDVDFile, &iso_size, &layer1_lba_start) < 0)
-            return -1;
+            diag_halt("Could not open the game image through UDPFS");
     }
 
     /*
@@ -798,7 +825,7 @@ int main(int argc, char *argv[])
             fd_system_cnf = read_system_cnf(sDVDFile, system_cnf_data, 128);
             if (fd_system_cnf < 0) {
                 printf("ERROR: Unable to read SYSTEM.CNF from ISO\n");
-                return -1;
+                diag_halt("Could not read SYSTEM.CNF from the game image");
             }
         } else {
             // Read SYSTEM.CNF from CD/DVD
@@ -1035,7 +1062,7 @@ int main(int argc, char *argv[])
      */
     uint8_t *irxptr_end = build_irx_table(sDVDFile != NULL);
     if (irxptr_end == NULL)
-        return -1;
+        diag_halt("Could not build the emulation module table");
 
     //
     // Set EE_CORE settings before loading into place
@@ -1044,6 +1071,12 @@ int main(int argc, char *argv[])
     strncpy(sys.eecore.GameID, sGameID, 12);
     sys.eecore.CheatList     = NULL;
     sys.eecore.ModStorageEnd = irxptr_end;
+    sys.eecore.IGRABIMagic = EECORE_IGR_ABI_MAGIC;
+    sys.eecore.IGRFlags = sys.bIGRPowerReset ? EECORE_IGR_FLAG_POWER_BUTTON_RESET : 0;
+    memset(sys.eecore.IGRExitPath, 0, sizeof(sys.eecore.IGRExitPath));
+    if (sys.sIGRPath != NULL)
+        strncpy(sys.eecore.IGRExitPath, sys.sIGRPath,
+                sizeof(sys.eecore.IGRExitPath) - 1);
 
     // Append cheat data after IRX table and point CheatList to it
     if (sys.cheats != NULL && sys.cheats_count > 0) {
@@ -1190,5 +1223,5 @@ int main(int argc, char *argv[])
 
     ExecPS2((void *)eh->entry, NULL, ee_core_argc, ee_core_argv);
 
-    return 0;
+    diag_halt("ExecPS2 returned unexpectedly");
 }

--- a/iop/cdvdfsv/src/cdvdfsv.c
+++ b/iop/cdvdfsv/src/cdvdfsv.c
@@ -22,10 +22,12 @@ static void cdvdfsv_startrpcthreads(void);
 static void cdvdfsv_rpc0_th(void *args);
 static void cdvdfsv_rpc1_th(void *args);
 static void cdvdfsv_rpc2_th(void *args);
+static void cdvdfsv_rpc_sd_th(void *args);
 static void *cbrpc_cdinit(int fno, void *buf, int size);
 static void *cbrpc_cddiskready(int fno, void *buf, int size);
 static void *cbrpc_cddiskready2(int fno, void *buf, int size);
 static void *cbrpc_S596(int fno, void *buf, int size);
+static void *cbrpc_shutdown(int fno, void *buf, int size);
 
 u8 *cdvdfsv_buf;
 int cdvdfsv_size;
@@ -34,13 +36,16 @@ int cdvdfsv_sectors;
 static SifRpcDataQueue_t rpc0_DQ;
 static SifRpcDataQueue_t rpc1_DQ;
 static SifRpcDataQueue_t rpc2_DQ;
+static SifRpcDataQueue_t rpc_sd_DQ;
 static SifRpcServerData_t cdinit_rpcSD, cddiskready_rpcSD, cddiskready2_rpcSD;
 static SifRpcServerData_t S596_rpcSD;
+static SifRpcServerData_t sd_rpcSD;
 
 static u8 cdinit_rpcbuf[16];
 static u8 cddiskready_rpcbuf[16];
 static u8 cddiskready2_rpcbuf[16];
 static u8 S596_rpcbuf[16];
+static u8 shutdown_rpcbuf[16];
 
 static int rpc0_thread_id, rpc1_thread_id, rpc2_thread_id, rpc_sd_thread_id;
 
@@ -185,6 +190,20 @@ static void cdvdfsv_startrpcthreads(void)
 
     rpc0_thread_id = CreateThread(&thread_param);
     StartThread(rpc0_thread_id, NULL);
+
+    // Private OPL-compatible shutdown endpoint used by ee_core IGR. Keep it
+    // on its own queue so it can run even when a game has another CDVD RPC
+    // request in flight. Match OPL's priority and stack: this thread has to
+    // preempt a title that is continuously issuing CDVD/network requests and
+    // has enough stack to drain the backend and stop DEV9 safely.
+    thread_param.attr = TH_C;
+    thread_param.option = 0xABCD8003;
+    thread_param.thread = (void *)cdvdfsv_rpc_sd_th;
+    thread_param.stacksize = 0x1000;
+    thread_param.priority = 0x01;
+
+    rpc_sd_thread_id = CreateThread(&thread_param);
+    StartThread(rpc_sd_thread_id, NULL);
 }
 
 //-------------------------------------------------------------------------
@@ -232,6 +251,15 @@ static void cdvdfsv_rpc2_th(void *args)
     cdvdfsv_register_searchfile_rpc(&rpc2_DQ);
 
     sceSifRpcLoop(&rpc2_DQ);
+}
+
+//-------------------------------------------------------------------------
+static void cdvdfsv_rpc_sd_th(void *args)
+{
+    sceSifSetRpcQueue(&rpc_sd_DQ, GetThreadId());
+    sceSifRegisterRpc(&sd_rpcSD, 0x80000598, &cbrpc_shutdown,
+                      shutdown_rpcbuf, NULL, NULL, &rpc_sd_DQ);
+    sceSifRpcLoop(&rpc_sd_DQ);
 }
 
 //-------------------------------------------------------------------------
@@ -285,6 +313,18 @@ static void *cbrpc_S596(int fno, void *buf, int size)
         cdvdman_intr_ef = sceCdSC(CDSC_GET_INTRFLAG, &dummy);
         ClearEventFlag(cdvdman_intr_ef, ~CDVDEF_FSV_S596);
         WaitEventFlag(cdvdman_intr_ef, CDVDEF_FSV_S596, WEF_AND, NULL);
+    }
+
+    *(int *)buf = 1;
+    return buf;
+}
+
+//--------------------------------------------------------------
+static void *cbrpc_shutdown(int fno, void *buf, int size)
+{
+    if (fno == 1) {
+        int value = *(int *)buf;
+        sceCdSC(CDSC_NEUTRINO_SHUTDOWN, &value);
     }
 
     *(int *)buf = 1;

--- a/iop/cdvdman_emu/include/cdvdman_emu.h
+++ b/iop/cdvdman_emu/include/cdvdman_emu.h
@@ -79,4 +79,8 @@ void *sceGetFsvRbuf2(int *size);
 #define CDSC_GET_VERSION      0xFFFFFFF7 // Get CDVDMAN version.
 #define CDSC_SET_ERROR        0xFFFFFFFE // Used by CDVDFSV and CDVDSTM to set the error code (Typically READCF*).
 
+// Private shutdown command shared with the OPL-compatible IGR RPC. It locks
+// the emulated device and drains the current FHI request before an IOP reset.
+#define CDSC_NEUTRINO_SHUTDOWN 0x00000001
+
 #endif

--- a/iop/cdvdman_emu/src/cdvdman_read.c
+++ b/iop/cdvdman_emu/src/cdvdman_read.c
@@ -13,6 +13,31 @@ static int cdvdman_ReadingThreadID;
 #define BOUNCE_BUF_SECTORS 1
 static u8 bounce_buf[BOUNCE_BUF_SECTORS * 2048];
 volatile unsigned char sync_flag_locked;
+static volatile unsigned char shutdown_locked;
+
+
+//-------------------------------------------------------------------------
+void cdvdman_shutdown_io(void)
+{
+    int oldState;
+
+    // Block all reads that arrive after shutdown begins, then drain the one
+    // request (if any) already owned by the read thread. The IGR handler has
+    // suspended the game's EE threads, but IOP streaming callbacks can still
+    // attempt another read unless this permanent gate is set first.
+    CpuSuspendIntr(&oldState);
+    shutdown_locked = 1;
+    CpuResumeIntr(oldState);
+
+    while (sync_flag_locked)
+        WaitEventFlag(cdvdman_stat.intr_ef, CDVDEF_MAN_UNLOCKED, WEF_AND, NULL);
+
+    // Do not power DEV9 off here. OPL deliberately keeps DEV9 alive for IGR
+    // and reserves DeviceStop/Dev9CardStop for a real power-off request. On
+    // hardware, calling dev9Shutdown() here made the following reset-packet
+    // submission stall at the blue diagnostic stage. Locking new reads and
+    // draining the active read is sufficient for the IOP reboot to take over.
+}
 
 
 //-------------------------------------------------------------------------
@@ -339,6 +364,9 @@ int sceCdRead_internal(u32 lsn, u32 sectors, void *buf, sceCdRMode *mode, enum E
     int OldState;
     u16 sector_size = 2048;
     int intct = QueryIntrContext();
+
+    if (shutdown_locked)
+        return 0;
 
 #ifdef DEBUG
     if (mode != NULL)

--- a/iop/cdvdman_emu/src/cdvdman_read.h
+++ b/iop/cdvdman_emu/src/cdvdman_read.h
@@ -10,6 +10,10 @@ typedef void (*StmCallback_t)(void);
 
 extern volatile unsigned char sync_flag_locked;
 
+// Prevent new reads and wait for the current backend request to complete.
+// The lock intentionally remains held until the imminent IOP reset.
+void cdvdman_shutdown_io(void);
+
 
 void cdvdman_read_init();
 

--- a/iop/cdvdman_emu/src/ioops.c
+++ b/iop/cdvdman_emu/src/ioops.c
@@ -586,6 +586,10 @@ int sceCdSC(int code, int *param)
     M_DEBUG("%s(0x%X, 0x%X)\n", __FUNCTION__, code, *param);
 
     switch (code) {
+        case CDSC_NEUTRINO_SHUTDOWN:
+            cdvdman_shutdown_io();
+            result = 1;
+            break;
         case CDSC_GET_INTRFLAG:
             result = cdvdman_stat.intr_ef;
             break;


### PR DESCRIPTION
## Summary

This draft ports an OPL-derived in-game reset implementation into Neutrino as an optional EE-core feature:

- detects `L1+L2+R1+R2+Start+Select` on controller ports 0 and 1;
- repeatedly scans for games that load libpad/libpad2 after startup;
- supports an opt-in short front-panel power-button reset path;
- performs a two-stage return to the ELF supplied by `-igr-path`;
- validates loader/EE-core ABI compatibility; and
- adds Mode 6 (`DISABLE_IGR`) for incompatible games.

The branch is deliberately based directly on current upstream `master`; it contains none of the unrelated UDPFS server/cache commits from the hardware-development branch.

## Hardware status

The reset path has completed successfully on real PS2 hardware in multiple titles and from both controller ports. It is not yet claimed to be universal: Q-Ball and some similar titles can damage or evade the resident worker, and those titles require Mode 6 while compatibility work continues. The front-panel path is opt-in with `-igr-power=1`.

See `docs/igr-hardware-testing.md` for the test matrix, limitations, deterministic preservation-build hashes, and attribution. Opening as a draft to get early architecture/compatibility feedback before claiming release readiness.