### PR TITLE
fix(dev9): recover wedged SPEED/SMAP block on warm-start (in-game IOP reboot)

### DIFF
--- a/iop/dev9/src/ps2dev9.c
+++ b/iop/dev9/src/ps2dev9.c
@@ -1269,6 +1269,19 @@ static int expbay_init(int sema_attr)
     _sw(0xe01a3043, SSBUS_R_1418);
     _sw(0xef1a3043, SSBUS_R_141c);
 
+    if (DEV9_REG(DEV9_R_POWER) & 0x04) {
+        // Warm start (e.g. in-game IOP reboot with the device left powered):
+        // on some consoles (seen on a slim) the SPEED/SMAP block is wedged at
+        // this point and only recovers after a full power cycle. Mirror the
+        // expbay branch of dev9Shutdown(), then run the normal cold init.
+        DEV9_REG(DEV9_R_1466)  = 1;
+        DEV9_REG(DEV9_R_1464)  = 0;
+        DEV9_REG(DEV9_R_1460)  = DEV9_REG(DEV9_R_1464);
+        DEV9_REG(DEV9_R_POWER) = DEV9_REG(DEV9_R_POWER) & ~4;
+        DEV9_REG(DEV9_R_POWER) = DEV9_REG(DEV9_R_POWER) & ~1;
+        DelayThread(1000000);
+    }
+
     if ((DEV9_REG(DEV9_R_POWER) & 0x04) == 0) { // if not already powered
         DEV9_REG(DEV9_R_1466) = 1;
         DEV9_REG(DEV9_R_1464) = 0;


### PR DESCRIPTION
## Summary

PR for the fix discussed in #201 — the maintainer asked for this to be submitted upstream.

On some PS2 slim consoles, `expbay_init()` sees `DEV9_R_POWER` already set after neutrino's in-game IOP reboot and skips the cold init path (`speed_device_init()` etc.), leaving the SMAP NIC wedged and dead at L2 (no ARP response). The launcher environment always cold-starts the chip, which is why browsing (e.g. NHDDL) works over UDPFS but in-game UDPFS does not.

## Fix

Mirror the expbay branch of `dev9Shutdown()` before falling through to the normal cold init whenever the device is already powered, so a warm-started chip gets properly power-cycled first.

## Test plan

- [x] Built `dev9_ns.irx` from `06188cc` with only this change (`make DEV9_NO_SHUTDOWN=1`) and confirmed in-game UDPFS DISCOVERY now succeeds ~5s after launch, game boots and streams normally — see #201 for the original report/trace.
- [x] Reproduced reliably on the affected PS2 Slim console; without the patch it fails 100% of the time.
- [ ] Not yet tested on non-affected consoles (fat/other slim revisions) — happy to adjust if this needs to be scoped more narrowly (e.g. only on `resetcount > 0`).

Fixes #201