### PR TITLE
The Jungle Book: Rhythm n' Groove - A Black Screen fix.

### DIFF
--- a/ee/loader/config/compat.toml
+++ b/ee/loader/config/compat.toml
@@ -160,6 +160,7 @@ MODE9 = {name = "Compat MODE9: NOP"}
 "SLES_503.26" = {name = "Max Payne",                             eecore.irm = [2, 2, 1]}
 
 # Workarounds, need to find a better solution
+"SLUS_200.75" = {name = "The Jungle Book Rhythm n' Groove",      eecore.irm = [2, 4, 0]}
 "SLUS_200.77" = {name = "Donald Duck - Goin' Quackers",          eecore.irm = [2, 4, 0]}
 "SLES_500.48" = {name = "Donald Duck - Quack Attack",            eecore.irm = [2, 4, 0]}
 "SLES_503.55" = {name = "Batman - Vengeance",                    eecore.irm = [2, 4, 0]}


### PR DESCRIPTION
Workaround for The Jungle Book: Rhythm n' Groove to help to launch this game.
Although there is still a stuttering in FMVs. Probably due to a high bitrate.