### PR TITLE
[README] +3 Neutrino Ready Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ Loader | Author
 [RETROLauncher](https://github.com/Spaghetticode-Boon-Tobias/RETROLauncher) | Boon Tobias
 [OSD-XMB](https://github.com/HiroTex/OSD-XMB) | Hiro Tex
 [PSBBN](https://github.com/CosmicScale/PSBBN-Definitive-English-Patch) + [BBNL](https://github.com/pcm720/bbnl) | CosmicScale + pcm720
-[RiptOPL](https://github.com/NathanNeurotic/Open-PS2-Loader). | NathanNeurotic
-[wOPL](https://github.com/ps2homebrew/wOPL). | KrahJohlito
-[Modulo](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2). | AdityaKumar7209
+[RiptOPL](https://github.com/NathanNeurotic/Open-PS2-Loader) | NathanNeurotic
+[wOPL](https://github.com/ps2homebrew/wOPL) | KrahJohlito
+[Modulo](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2) | AdityaKumar7209
 
 Add your project here? Send me a PR.

--- a/README.md
+++ b/README.md
@@ -238,5 +238,8 @@ Loader | Author
 [RETROLauncher](https://github.com/Spaghetticode-Boon-Tobias/RETROLauncher) | Boon Tobias
 [OSD-XMB](https://github.com/HiroTex/OSD-XMB) | Hiro Tex
 [PSBBN](https://github.com/CosmicScale/PSBBN-Definitive-English-Patch) + [BBNL](https://github.com/pcm720/bbnl) | CosmicScale + pcm720
+[RiptOPL](https://github.com/NathanNeurotic/Open-PS2-Loader). | NathanNeurotic
+[wOPL](https://github.com/ps2homebrew/wOPL). | KrahJohlito
+[Modulo](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2). | AdityaKumar7209
 
 Add your project here? Send me a PR.


### PR DESCRIPTION
Modulo strictly uses Neutrino (global)
RiptOPL supports neutrino as an option for game launches. (per game or global)
Confirmed working.

wOPL supports neutrino as well, but I have not tested since uOPL. I included it anyway as its a claimed feature. (Per-game I believe)

Thank you for your work, these projects would be much less if anything at all without your work!